### PR TITLE
added system-tests direcotry to the setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,7 @@ then
 fi
 
 install frontend
+install system-tests
 
 ./etc/etc-hosts.sh local.rosalution.cgds
 


### PR DESCRIPTION
This will run the `yarn install` command in the system-tests directory during the run of the `setup.sh` script.

---
Wrike Task: [Update setup.sh in Rosalution to include doing a yarn install for system testing](https://www.wrike.com/open.htm?id=1020135092)

---
Change made:

added `install system-tests` to the script



