### PR TITLE
Updated the validation of the application settings for more intuitive validation failure

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -5,7 +5,7 @@ Specifically the SECRET_KEY parameter can be generated and changed with each run
 """
 # pylint: disable=too-few-public-methods
 from functools import lru_cache
-from pydantic import BaseSettings
+from pydantic import BaseSettings, root_validator
 
 
 class Settings(BaseSettings):
@@ -25,6 +25,19 @@ class Settings(BaseSettings):
     cas_api_service_url: str = "http://dev.cgds.uab.edu/rosalution/api/auth/login?nexturl=%2F"
     cas_server_url: str = "https://padlockdev.idm.uab.edu/cas/"
     cas_login_enable: bool = False
+
+    @root_validator(pre=True)
+    @classmethod
+    def rosalution_key_exists(cls, values):
+        """
+        Verifies that the ROSALUTION_KEY environment is set and provides a more descriptive error message.
+        This needed to be done as a pydantic root validator to execute this before pydantics validation of
+        individual fields since it would fail due to the missing value.
+        """
+        key = values.get('rosalution_key')
+        if not key:
+            raise ValueError('Environment variable "ROSALUTION_KEY" missing. App requires secret for secure encoding.')
+        return values
 
 
 @lru_cache()


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

Wrike Ticket - [Improve the Rosalution API startup error message when validation fails to find the required "ROSALUTION_KEY" environment variable](https://www.wrike.com/open.htm?id=1033376951)

Changes made:

* Updated the backend API to validate if the ROSALUTION_KEY is provided.  If not, a value error is returned with a more descriptive message of the failure explaining that it is trying to read it from an Environment variable that is not sent.

**To Review:**
<!-- Make a to do list of things to check for to approve the pull request -->
<!-- Modify the below list as appropriate by editing and deleting text that is not applicable-->

- [x] Static Analysis by Reviewer
- [x] The changes made to starting up the rosalution backend are working as intended/rendered correctly.
  To check this run the following commands:

1.  Open the `docker-compose.yml` and comment out line 49 that contains setting the `ROSALUTION_KEY` environment variable.  this will ensure that the value is not being set in the container.
2. Deploy Rosalution and wait for it to completely startup
  ``` bash
docker-compose up --build -d
  ```
3. View the logs for the backend container
```bash
docker logs <backend-container-name>
```

The error should read like the following

 `Environment variable "ROSALUTION_KEY" missing. App requires secret for secure encoding. (type=value_error)`

- [x] All Github Actions checks have passed.

