### PR TITLE
Remove ROSALUTION_KEY from local development environment depdency

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -2,9 +2,6 @@ name: System Tests
 
 on: [push, workflow_dispatch]
 
-env:
-  ROSALUTION_KEY: not-a-real-key-but-need-to-resolve
-
 jobs:
   system-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -75,11 +75,8 @@ The script will
 - `yarn install` within each subdirectory
 - Updates your local `/etc/hosts` to support the local DNS name redirect
 'local.rosalution.cgds' to localhost.
-- creates a virtual environment for Python called "rosalution_env" within the backend directory and activates it.
-- installs Python dependencies within the virtual environment and then deactivates the virtual environment.
-- Updates ~/.bashrc file by appending a randomly generated key in `ROSALUTION_KEY`
-as an environment variable used for the backend service's auth.
-    - Source the `.bashrc` if you are to deploy within the same terminal session.
+- creates a virtual environment for Python called "rosalution_env" within the backend directory
+- installs Python dependencies within the virtual environment
 
 ```bash
 ./setup.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 COPY ./src /app/src
+COPY etc/entrypoint-init.sh /app/entrypoint-init.sh
 ENTRYPOINT ["/bin/sh", "-c", "uvicorn src.main:app --host 0.0.0.0 --port 8000 --log-level info --reload"]
 
 # Production Build Stage

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 COPY ./src /app/src
-COPY etc/entrypoint-init.sh /app/entrypoint-init.sh
 ENTRYPOINT ["/bin/sh", "-c", "uvicorn src.main:app --host 0.0.0.0 --port 8000 --log-level info --reload"]
 
 # Production Build Stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ./backend:/app
     environment:
       - MONGODB_HOST=rosalution-db
-      - ROSALUTION_KEY
+    entrypoint: ['/bin/sh', '-c', './entrypoint-init.sh']
     networks:
       - rosalution-network
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ./backend:/app
     environment:
       - MONGODB_HOST=rosalution-db
-    entrypoint: ['/bin/sh', '-c', './entrypoint-init.sh']
+    entrypoint: ['/bin/sh', '-c', './etc/entrypoint-init.sh']
     networks:
       - rosalution-network
     labels:

--- a/setup.sh
+++ b/setup.sh
@@ -40,16 +40,4 @@ pip3 install -r requirements.txt
 # deactivate venv and return to root directory
 deactivate
 cd - || { echo "Unable to change return to root directory"; exit 1; }
-
-key=$(head -c 65 < /dev/random | base64 |  tr -dc A-Za-z0-9)
-if grep -Fq "ROSALUTION_KEY" ~/.bashrc
-then
-    replace_value="ROSALUTION_KEY=$key"
-    sed "s,ROSALUTION_KEY=[^;]*,$replace_value,"  ~/.bashrc > ~/.bashrc.bak && mv ~/.bashrc.bak ~/.bashrc
-    echo "Updating rosalution_key in ~/.bashrc ..."
-else
-    echo  "export ROSALUTION_KEY=$key" >> ~/.bashrc
-    echo "Setting rosalution_key in ~/.bashrc ..."
-fi
-echo "Source your ~/.bashrc to load the updated environment"
 echo "Use 'source backend/rosalution_env/bin/activate' to activate the virtual environment"


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

Wrike Ticket - [Remove ROSALUTION_KEY from local development environment depdency](https://www.wrike.com/open.htm?id=1046455694)

Changes made:

Removed Rosalution's local deployment relying on modifications to the local development environment in a Bash shell's `~/.bashrc`.  This caused many problems for folks trying to try out deploying the application locally and adds additional complication to support the user of other shell envrionments. Newer versions of macosx use Z shell instead of Bash.

- Removed the environment key set in the system tests environment in the github actions workflow
- Updated primary README documentation removing reference to the ROSALUTION_KEY
- Updated local docker compose yml to not include the ROSALUTION_KEY and set the entrypoint for the backend to be the entrypoint-init.sh script
- Updated the setuplsh to not generate and update the .bashrc file.


**To Review:**
- [x] Static Analysis by Reviewer
- [x] Deploy Rosalution for local development then run system testing.

 ```bash
./setup.sh clean
docker compose down
docker system prune -a --volumes
docker compose up --build -d
cd system-tests
yarn test:e2e
 ```

- [x] Deploy Rosalution production images for local development and do a visual inspection if it works (cannot login due to needing CAS working)

 ``` bash
./setup.sh clean
docker compose down
docker system prune -a --volumes
docker compose -f docker-compose.local-production.yml up --build
  ```

- [x] Run ./build.sh and verify there are no new error outputs
``` bash
./setup.sh clean
docker compose down
docker system prune -a --volumes
./build.sh
```

- [x] Did python unit tests pass? 
