### PR TITLE
Adding positional argument expansion to forward entrypoint arguments to backend uvicorn executable

### DIFF
--- a/backend/etc/entrypoint-init.sh
+++ b/backend/etc/entrypoint-init.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 ROSALUTION_KEY="$(< /dev/urandom tr -dc A-Za-z0-9  | head -c 65)" && export ROSALUTION_KEY && \
-   uvicorn src.main:app --host 0.0.0.0 --port 8000 --log-level info
+   uvicorn src.main:app --host 0.0.0.0 --port 8000 --log-level info "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ./backend:/app
     environment:
       - MONGODB_HOST=rosalution-db
-    entrypoint: ['/bin/sh', '-c', './etc/entrypoint-init.sh']
+    entrypoint: ['/bin/sh', '-c', './etc/entrypoint-init.sh --reload']
     networks:
       - rosalution-network
     labels:


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.

## Pull Request Details

Wrike Ticket - [Fix hot-reloading backend service with rosalution_key/entrypoint changes done](https://www.wrike.com/open.htm?id=1046455694)

Changes made:

Updated the backend entrypoint-init.sh script used to start the application and generate the rosalution_key inside the docker container at startup.  Forgot to add in the script to apply to expand the positional arguments provided to it to forward setting the backend service to hot-reload changes it observes to speed up development.

**To Review:**
- [x] Static Analysis by Reviewer
- [x] Build and deploy rosalution and look at backend service logs 

``` bash
docker compose up --build backend
  ```

![image](https://user-images.githubusercontent.com/1209059/216437954-6fd5bd13-f59f-44bc-a212-345fb8389799.png)

- [x] All Github Actions checks have passed.
