### PR TITLE
Resolving why annotation is halting halfway for a new sample

### DIFF
--- a/backend/src/core/annotation_task.py
+++ b/backend/src/core/annotation_task.py
@@ -6,16 +6,22 @@ import time
 # pylint: disable=too-few-public-methods
 # Disabling too few public metods due to utilizing Pydantic/FastAPI BaseSettings class
 import jq
+import json
 import requests
 
-# def log_to_file(string):
-#     """
-#     Temprorary utility function for development purposes abstracted for testing.
-#     Will remove once feature is completed.
-#     """
-#     with open("rosalution-annotation-log.txt", mode="a", encoding="utf-8") as log_file:
-#         log_file.write(string)
-#     print(string)
+
+def empty_gen():
+    yield from ()
+
+
+def log_to_file(string):
+    """
+    Temprorary utility function for development purposes abstracted for testing.
+    Will remove once feature is completed.
+    """
+    with open("rosalution-annotation-log.txt", mode="a", encoding="utf-8") as log_file:
+        log_file.write(string)
+    print(string)
 
 
 class AnnotationTaskInterface:
@@ -67,7 +73,14 @@ class AnnotationTaskInterface:
             }
 
             replaced_attributes = self.aggregate_string_replacements(self.dataset['attribute'])
-            jq_results = iter(jq.compile(replaced_attributes).input(json_result).all())
+            jq_results = empty_gen()
+            print(jq_results)
+            try:
+                jq_results = iter(jq.compile(replaced_attributes).input(json_result).all())
+            except ValueError as value_error:
+                log_to_file(
+                    f"Failed to annotate '{annotation_unit['data_set']}' from '{annotation_unit['data_source']}' on {json.dumps(json_result)} with error '{value_error}'"
+                )
             jq_result = next(jq_results, None)
             while jq_result is not None:
                 result_keys = list(jq_result.keys())

--- a/backend/tests/unit/core/test_annotation_task.py
+++ b/backend/tests/unit/core/test_annotation_task.py
@@ -45,7 +45,7 @@ def test_extraction_forge_gene_linkout_dataset(forge_annotation_task_gene):
 
 
 def test_annotation_extraction_for_transcript_id_dataset(http_annotation_transcript_id, transcript_annotation_response):
-    """Verifieng genomic unit extraction for a transcript using the the transcript ID dataset"""
+    """Verifying genomic unit extraction for a transcript using the the transcript ID dataset"""
     actual_extractions = http_annotation_transcript_id.extract(transcript_annotation_response)
     assert len(actual_extractions) == 2
     assert {
@@ -62,7 +62,7 @@ def test_annotation_extraction_for_transcript_id_dataset(http_annotation_transcr
 def test_annotation_extraction_for_polyphen_prediction_transcript_dataset(
     http_annotation_polyphen_prediction, transcript_annotation_response
 ):
-    """Verifieng genomic unit extraction for a transcript using the the transcript ID dataset"""
+    """Verifying genomic unit extraction for a transcript using the the transcript ID dataset"""
     actual_extractions = http_annotation_polyphen_prediction.extract(transcript_annotation_response)
     assert len(actual_extractions) == 2
 
@@ -79,13 +79,24 @@ def test_annotation_extraction_for_polyphen_prediction_transcript_dataset(
 
 
 def test_annotation_extraction_for_genomic_unit(http_annotation_task_gene, hpo_annotation_response):
-    """Verifieng genomic unit extraction for a gene using the HPO dataset"""
+    """Verifying genomic unit extraction for a gene using the HPO dataset"""
     actual_extractions = http_annotation_task_gene.extract(hpo_annotation_response)
     assert len(actual_extractions) == 1
     assert {
         'data_set': 'HPO', 'data_source': 'HPO', 'version': '',
         'value': ['Myopathy, X-linked, With Excessive Autophagy']
     } in actual_extractions
+
+
+def test_annotation_extraction_value_error_exception(http_annotation_task_gene, hpo_annotation_response):
+    """Verifying annotation failure does not cause crash in application during extraction"""
+
+    # Removing the expected value in the json to force a jq parse error to more closely
+    # emulate the failure instead of mocking the jq response to fail.
+    del hpo_annotation_response['diseaseAssoc']
+
+    actual_extractions = http_annotation_task_gene.extract(hpo_annotation_response)
+    assert len(actual_extractions) == 0
 
 
 ## Fixtures ##

--- a/etc/fixtures/initial-seed/annotations-config.json
+++ b/etc/fixtures/initial-seed/annotations-config.json
@@ -5,7 +5,7 @@
     "genomic_unit_type": "gene",
     "annotation_source_type": "http",
     "url": "https://hpo.jax.org/api/hpo/search/?q={gene}&max=-1&offset=0&category=genes",
-    "attribute": ".genes[] | select( .entrezGeneSymbol | contains(\"{gene}\")) |  { entrezGeneId: .entrezGeneId }"
+    "attribute": ".genes[] | select( .geneSymbol | contains(\"{gene}\")) |  { entrezGeneId: .geneId}"
   },
   {
     "data_set": "Ensembl Gene Id",

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,7 @@ clean_option="clean"
 if [[ $# -ne 0 ]] && [[ $1 -eq $clean_option ]]
 then
     clean frontend
+    rm -rf backend/rosalution_env
 fi
 
 install frontend


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

Wrike Ticket - [Investigate why annotation is halting halfway for a new sample](https://www.wrike.com/open.htm?id=1047573962)

Upon investigating why annotations were halting halfway, I discovered that an exception being thrown from an invalid 'jq' query occurring. A failure in extracting the annotation from 'jq' ought to not cause the entire threadpool to crash and halt annotations.  Since there were plenty of annotations left on the queue, most of the remaining annotations would run when another case was added to the application.

Also, discovered the annotation in question causing the issue is the "Entrez Gene Id" that is being queried from a gene symbol for HPO.  HPO released a new version of their API in place of their old one, causing the failure to occur.  Updated the base fixtures to accommodate the failure; the annotation itself did not need a code change. 

The changes included
- a refactor to include additional try/catch to handle the situation of an annotation extraction error.  Logging to the file for annotations is added for this situation to help track in the future and corresponding unit tests to verify it worked
- updated configuration for the new extraction query for the entrez gene id from HPO
- Also noted that the setup.sh script for the python environment doesn't remove the virtual environment using a clean run.  Discovered this while trying to clean up the virtual environment on running the script Decided to include the additional here.

**To Review:**
- [x] Static Analysis by Reviewer
- [x] The changes made ensure uploading and annotations run correctly for new cases
  To check this run the following commands:

1. Redeploy Rosalution with a completely clean local development environment 

  ``` bash
./setup.sh clean
docker compose down
docker system prune -a --volumes
docker compose up  --build -d
  ```
2. Visit [local.rosalution.cgds/rosalution](http://local.rosalution.cgds/rosalution/) and login as 'user01'.
3. Click the "Create New Analysis" card and upload any of the valid cases in <rosalution>/etc/fixtures/import. (My example below used CPAM0074). 
4. After a successful upload, reload the home page and click the new case card.  Select any of the variants to view their annotations.  Some of the variant annotations ought to have populated (not all of them because it can take several seconds). See the screenshot below as an example.

- [ ] List any other checks needed to be reviewed.
- [ ] All Github Actions checks have passed.

### Screenshots
![image](https://user-images.githubusercontent.com/1209059/216667233-46f1b784-f8e3-4622-953f-f52170519ff1.png)