### PR TITLE
Refactored analysis summaries for grouping genomic units more clearly

### DIFF
--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -60,7 +60,7 @@ class BaseAnalysis(BaseModel):
 class AnalysisSummary(BaseAnalysis):
     """Models the summary of an analysis"""
 
-    genomic_units: List = []
+    genomic_units: List[GenomicUnit] = []
 
 
 class Analysis(BaseAnalysis):

--- a/backend/src/repository/analysis_collection.py
+++ b/backend/src/repository/analysis_collection.py
@@ -35,28 +35,21 @@ class AnalysisCollection:
         })
 
         summaries = []
-        for summary in query_result:
-            genes_list = map(lambda unit: unit['gene'], summary['genomic_units'])
-            genes_string_list = ', '.join(genes_list)
-
-            transcripts_list = [[transcript_unit['transcript']
-                                 for transcript_unit in unit['transcripts']]
-                                for unit in summary['genomic_units']]
-            flattened_transcripts_list = [
-                transcript for transcript_items in transcripts_list for transcript in transcript_items
-            ]
-
-            variant_list = [
-                f"{variant['c_dot']} ({variant['p_dot']})" for genomic_unit in summary['genomic_units']
-                for variant in genomic_unit['variants'] if variant['c_dot']
-            ]
-
-            genomic_units_summary = [{
-                "gene": genes_string_list, "transcripts": flattened_transcripts_list, "variants": variant_list
-            }]
-
-            summary['genomic_units'] = genomic_units_summary
-            summaries.append(summary)
+        for analysis in query_result:
+            genomic_unit_summaries = []
+            for unit in analysis['genomic_units']:
+                genomic_unit_summary = {}
+                if unit.get('gene'):
+                    genomic_unit_summary['gene'] = unit['gene']
+                genomic_unit_summary['variants'] = []
+                for variant in unit['variants']:
+                    summary_variant = variant['hgvs_variant']
+                    if variant['p_dot'] is not None:
+                        summary_variant = f"{summary_variant}({variant['p_dot']})"
+                    genomic_unit_summary['variants'].append(summary_variant)
+                genomic_unit_summaries.append(genomic_unit_summary)
+            analysis['genomic_units'] = genomic_unit_summaries
+            summaries.append(analysis)
 
         return summaries
 

--- a/frontend/src/components/AnalysisListing/AnalysisCard.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisCard.vue
@@ -23,21 +23,16 @@
             </span>
         </div>
         <div class="genomic-units-section">
-        <ul aria-label="Gene:">
-          <li v-for="genomic_unit in genomic_units" :key="genomic_unit">
-            {{ genomic_unit.gene }}
-          </li>
-        </ul>
-        <ul aria-label="Transcript:">
-          <li v-for="genomic_unit in genomic_units" :key="genomic_unit">
-            {{ genomic_unit.transcripts.join(", ") }}
-          </li>
-        </ul>
-        <ul aria-label="Variant:">
-          <li v-for="genomic_unit in genomic_units" :key="genomic_unit">
-            {{ genomic_unit.variants.join(", ") }}
-          </li>
-        </ul>
+          <ul>
+            <li v-for="genomic_unit in genomic_units" :key="genomic_unit">
+              <span class="gene-genomic-unit-text">{{ genomic_unit.gene || ""}}</span>
+              <ul>
+                <li v-for="variant in genomic_unit.variants" :key="variant" class="variant-genomic-unit-text">
+                  {{ variant }}
+                </li>
+              </ul>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -200,7 +195,6 @@ div {
 .middle-separator {
   min-width: 1px;
   max-width: 1px;
-  margin: var(--p-1);
   background-color: var(--rosalution-grey-300);
 }
 
@@ -208,9 +202,16 @@ div {
   padding: var(--p-1) 0;
 }
 
-ul:before{
-  content:attr(aria-label);
-  color: var(--rosalution-grey-300);
+.gene-genomic-unit-text {
+  font-weight: bold;
+}
+
+.variant-genomic-unit-text {
+  background-color: var(--rosalution-grey-50);
+  border-radius: var(--input-border-radius);
+  padding: var(--p-1) var(--p-1) var(--p-1) var(--p-1);
+  word-wrap: break-word;
+  margin-bottom: var(--p-1);
 }
 
 </style>

--- a/frontend/src/components/DropDownMenu.vue
+++ b/frontend/src/components/DropDownMenu.vue
@@ -26,7 +26,7 @@ export default {
 
 </script>
 
-<style>
+<style scoped>
 hr {
   border: 1px solid var(--rosalution-grey-100);
 }

--- a/frontend/src/views/AnalysisListingView.vue
+++ b/frontend/src/views/AnalysisListingView.vue
@@ -123,6 +123,7 @@ export default {
         await notificationDialog
             .title('Successful import')
             .alert('Imported Phenotips Case successfully!');
+        await this.getListing();
       } catch (error) {
         await notificationDialog
             .title('Failed to import phenotips analysis')

--- a/frontend/test/components/AnalysisListing/AnalysisCard.spec.js
+++ b/frontend/test/components/AnalysisListing/AnalysisCard.spec.js
@@ -18,8 +18,7 @@ function getMountedComponent(props) {
     genomic_units: [
       {
         gene: 'LMNA',
-        transcripts: ['NM_001017980.3'],
-        variants: ['c.745C>T'],
+        variants: ['NM_001017980.3:c.745C>T'],
       },
     ],
     nominated_by: 'Dr. Person Two',
@@ -70,12 +69,10 @@ describe('AnalysisCard.vue', () => {
   describe('should show the genomic units of the case', () => {
     it('should show the gene information for a case', () => {
       const wrapper = getMountedComponent();
-      expect(wrapper.html()).to.contains('Gene');
       expect(wrapper.html()).to.contains('LMNA');
     });
     it('should show the transcript information for a case', () => {
       const wrapper = getMountedComponent();
-      expect(wrapper.html()).to.contains('Transcript');
       expect(wrapper.html()).to.contains('NM_001017980.3');
     });
     it('should show the coordinates information for a case', () => {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes..

## Pull Request Details

Wrike Ticket - [Revise the Analysis card on the Rosalution main page to group a gene and related variants visually](https://www.wrike.com/open.htm?id=1067982940)

- Refactored and simplified the analysis summary API endpoint used for the cards to to reflect the updated grouping
- Restructured the cards to group a gene with variants visually, and visually identifying each variant in a light grey pill shape.
- Reloads the analyses summary cards when a sucessful import

**To Review:**

- [x] Static Analysis by Reviewer
- [x] The changes made to the analysis cards are working as intended/rendered correctly.
  To check this run the following commands:

1.
  ``` bash
docker compose up
  ```
2. Visit http://local.rosalution.cgds/rosalution/
3. Login as 'user01'
4. Analysis cards look like screenshot below
5. Import a new analysis, these can be found in ./etc/fixtures/import
6. Does it immediately show up?

- [x] List any other checks needed to be reviewed.
- [x] All Github Actions checks have passed.

### Screenshots (if appropriate)

<img width="1494" alt="Screen Shot 2023-03-06 at 2 25 56 PM" src="https://user-images.githubusercontent.com/1209059/223229745-7a781a61-3612-4202-8220-d7db18df78c2.png">

