### PR TITLE
Account view-CredentialsBox component

### DIFF
--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -59,6 +59,10 @@ export default {
     content: {
       type: Array,
     },
+    onSecretGenerated: {
+      type: Function,
+      default: () => {},
+    },
   },
   data() {
     return {
@@ -71,6 +75,7 @@ export default {
     },
     generateSecret() {
       this.$emit('generateSecret');
+      this.onSecretGenerated();
     },
   },
 };

--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -1,0 +1,115 @@
+<template>
+  <table class="credentials-box-container">
+    <tbody>
+      <tr class="credentials-header">
+        <td class="credentials-header-content">
+          <h2 class="credentials-name">
+            {{header}}
+          </h2>
+        </td>
+      </tr>
+      <div class="separator"></div>
+      <tr class="field-value-row" v-for="content in contentList" :key="content">
+        <td>
+          <lable class="field"
+          v-bind:style="[content.value.length === 0 && !this.edit ? 'color: var(--rosalution-grey-300);'
+          : 'color: var(--rosalution-black);']">
+            {{content.field}}
+          </lable>
+        </td>
+        <td class="values">
+          <tr v-for="value in content.value" :key="value" class="value-row" data-test="value-row">
+            <a v-if="content.clickable" @click="toggle()">{{value}}</a>
+            <span v-else>
+              {{value}}
+            </span>
+          </tr>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+export default {
+  name: 'credentials-box',
+  emits: ['toggle'],
+  props: {
+    header: {
+      type: String,
+    },
+    content: {
+      type: Array,
+    },
+  },
+  data() {
+    return {
+      contentList: this.content,
+    };
+  },
+  methods: {
+    toggle() {
+      this.$emit('toggle');
+    },
+  },
+};
+</script>
+
+<style scoped>
+div {
+  font-family: "Proxima Nova", sans-serif;
+  padding: var(--p-0);
+}
+.credentials-box-container {
+  display: flex;
+  flex-direction: column;
+  padding: var(--p-10);
+  margin: var(--p-10);
+  width: 100%;
+  gap: var(--p-10);
+  border-radius: 1.25rem;
+  background-color: var(--rosalution-white);
+}
+
+.credentials-header {
+  height: 1.75rem;
+  display: flex;
+}
+
+.credentials-header-content {
+  display: flex;
+  align-items: center;
+  flex: 1 0 auto;
+}
+
+.separator {
+  height: .125rem;
+  background-color: var(--rosalution-grey-100);
+  border: solid .0469rem var(--rosalution-grey-100);
+}
+
+.field-value-row {
+  display: flex;
+  flex-direction: row;
+  gap: .625rem;
+  margin: 0.625rem 0.250rem 0.625rem 0.250rem;
+}
+
+.field {
+  display: inline-block;
+  width: 11.25rem;
+  height: 1.375rem;
+  margin: 0 1.1875rem .0063rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.values {
+  font-size: 1.125rem;
+  text-align: left;
+  color: var(--rosalution-black);
+  width: 100%;
+  display: block;
+}
+</style>

--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -9,21 +9,33 @@
         </td>
       </tr>
       <div class="separator"></div>
-      <tr class="field-value-row" v-for="content in contentList" :key="content">
+      <tr class="field-value-row">
         <td>
-          <lable class="field"
-          v-bind:style="[content.value.length === 0 && !this.edit ? 'color: var(--rosalution-grey-300);'
-          : 'color: var(--rosalution-black);']">
-            {{content.field}}
+          <lable class="field">
+            Client ID
           </lable>
         </td>
         <td class="values">
-          <tr v-for="value in content.value" :key="value" class="value-row" data-test="value-row">
-            <a v-if="content.clickable" @click="toggle()">{{value}}</a>
-            <span v-else>
-              {{value}}
-            </span>
+          <tr class="value-row" data-test="client-id-value-row">
+            {{clientId}}
           </tr>
+        </td>
+      </tr>
+      <tr class="field-value-row">
+        <td>
+          <lable class="field">
+            Client Secret
+          </lable>
+        </td>
+        <td class="values">
+          <tr class="value-row" data-test="client-secret-value-row">
+            <a class="clickable-text" @click="displaySecret()">{{clientSecret}}</a>
+          </tr>
+        </td>
+        <td class="button-row">
+          <button class="button" @click="generateSecret" type="submit">
+            Generate Secret
+          </button>
         </td>
       </tr>
     </tbody>
@@ -33,9 +45,15 @@
 <script>
 export default {
   name: 'credentials-box',
-  emits: ['toggle'],
+  emits: ['display-secret', 'generateSecret'],
   props: {
     header: {
+      type: String,
+    },
+    clientId: {
+      type: String,
+    },
+    clientSecret: {
       type: String,
     },
     content: {
@@ -48,8 +66,11 @@ export default {
     };
   },
   methods: {
-    toggle() {
-      this.$emit('toggle');
+    displaySecret() {
+      this.$emit('display-secret');
+    },
+    generateSecret() {
+      this.$emit('generateSecret');
     },
   },
 };
@@ -111,5 +132,25 @@ div {
   color: var(--rosalution-black);
   width: 100%;
   display: block;
+}
+
+.value-row {
+  font-size: 1.125rem;
+  color: var(--rosalution-black);
+  display: block;
+  width: 100%;
+}
+
+.button {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex: 1 0 auto;
+  background-color: var(--rosalution-purple-100);
+}
+
+.clickable-text {
+  color: var(--rosalution-purple-300);
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -32,7 +32,7 @@
             <a class="clickable-text" @click="displaySecret()">{{clientSecret}}</a>
           </tr>
         </td>
-        <td class="button-row">
+        <td>
           <button class="button" @click="generateSecret" type="submit">
             Generate Secret
           </button>
@@ -142,11 +142,20 @@ div {
 }
 
 .button {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  flex: 1 0 auto;
   background-color: var(--rosalution-purple-100);
+  color: var(--rosalution-purple-300);
+  border: none;
+  border-radius: .625rem;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: bold;
+  line-height: 1.625rem;
+  height: 2rem;
+  width: 9rem;
+  text-align: center;
+  justify-self: stretch;
+  cursor: pointer;
+  vertical-align: middle;
 }
 
 .clickable-text {

--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -11,9 +11,9 @@
       <div class="separator"></div>
       <tr class="field-value-row">
         <td>
-          <lable class="field">
+          <label class="field">
             Client ID
-          </lable>
+          </label>
         </td>
         <td class="values">
           <tr class="value-row" data-test="client-id-value-row">
@@ -23,9 +23,9 @@
       </tr>
       <tr class="field-value-row">
         <td>
-          <lable class="field">
+          <label class="field">
             Client Secret
-          </lable>
+          </label>
         </td>
         <td class="values">
           <tr class="value-row" data-test="client-secret-value-row">

--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -56,9 +56,9 @@ export default {
     clientSecret: {
       type: String,
     },
-    onSecretGenerated: {
-      type: Function,
-      default: () => {},
+    secretExists: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {
@@ -71,8 +71,7 @@ export default {
       this.$emit('display-secret');
     },
     generateSecret() {
-      this.$emit('generateSecret');
-      this.onSecretGenerated();
+      this.$emit('generate-secret');
     },
   },
 };

--- a/frontend/src/components/AccountView/CredentialsBox.vue
+++ b/frontend/src/components/AccountView/CredentialsBox.vue
@@ -45,7 +45,7 @@
 <script>
 export default {
   name: 'credentials-box',
-  emits: ['display-secret', 'generateSecret'],
+  emits: ['display-secret', 'generate-secret'],
   props: {
     header: {
       type: String,
@@ -55,9 +55,6 @@ export default {
     },
     clientSecret: {
       type: String,
-    },
-    content: {
-      type: Array,
     },
     onSecretGenerated: {
       type: Function,

--- a/frontend/src/components/AnalysisView/SectionBox.vue
+++ b/frontend/src/components/AnalysisView/SectionBox.vue
@@ -18,7 +18,7 @@
           </label>
         </td>
       </tr>
-      <div class="seperator"></div>
+      <div class="separator"></div>
         <tr class="field-value-row" v-for="content in contentList" :key="content">
           <td v-if="!this.sectionImageExist">
             <label class="field"
@@ -163,7 +163,7 @@ div {
   cursor: pointer;
 }
 
-.seperator {
+.separator {
   height: .125rem;
   background-color: var(--rosalution-grey-100);
   border: solid .0469rem var(--rosalution-grey-100);

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -85,8 +85,8 @@ export default {
     async onGenerateSecret() {
       await authStore.generateSecret();
       const updatedUser = await authStore.getAPICredentials();
-      console.log(updatedUser)
-      console.log(updatedUser.client_secret)
+      console.log(updatedUser);
+      console.log(updatedUser.client_secret);
       this.clientSecret = updatedUser.client_secret;
     },
     async onLogout() {

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -16,13 +16,13 @@
           { field: 'Full Name', value: [user.full_name] },
           { field: 'Email', value: [user.email] },
         ]" />
-      <SectionBox
+      <CredentialsBox
         :header="'Credentials'"
         :content= credentialsContent
-        @click="toggleSecret"
         data-test="credentials"
         :key="showSecretValue"
-      />
+        @toggle= this.ontoggleSecret
+        />
       <button @click="generateSecret" type="submit">
         Generate Secret
       </button>
@@ -32,6 +32,7 @@
 
 <script>
 import SectionBox from '@/components/AnalysisView/SectionBox.vue';
+import CredentialsBox from '@/components/AccountView/CredentialsBox.vue';
 
 import {authStore} from '../stores/authStore';
 
@@ -42,6 +43,7 @@ export default {
   components: {
     RosalutionHeader,
     SectionBox,
+    CredentialsBox,
   },
   data() {
     return {
@@ -58,6 +60,7 @@ export default {
         {
           field: 'Client Secret',
           value: this.secretValue,
+          clickable: true,
         },
       ];
       return content;
@@ -80,7 +83,7 @@ export default {
     async onLogout() {
       this.$router.push({path: '/rosalution/logout'});
     },
-    toggleSecret() {
+    async ontoggleSecret() {
       if (!this.showSecretValue && this.secretValue[0] !== '<empty>') {
         this.showSecretValue = !this.showSecretValue;
       }

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -69,7 +69,7 @@ export default {
       return '<empty>';
     },
     clientSecretExists() {
-      return !!this.clientSecret;
+      return Boolean(this.clientSecret);
     },
   },
   methods: {

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -23,7 +23,7 @@
         data-test="credentials"
         :key="showSecretValue"
         @display-secret= this.onToggleSecret
-        @generateSecret = this.onGenerateSecret
+        @generate-secret = this.onGenerateSecret
         :onSecretGenerated="updateSecretValue"
         />
     </app-content>
@@ -58,18 +58,6 @@ export default {
     user() {
       return authStore.getUser();
     },
-    credentialsContent() {
-      const content = [
-        {field: 'Client ID', value: [this.user.clientId]},
-        {
-          field: 'Client Secret',
-          value: this.secretValue,
-          clickable: true,
-        },
-      ];
-      return content;
-    },
-
     secretValue() {
       if (this.showSecretValue) {
         return this.clientSecret;

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -85,8 +85,6 @@ export default {
     async onGenerateSecret() {
       await authStore.generateSecret();
       const updatedUser = await authStore.getAPICredentials();
-      console.log(updatedUser);
-      console.log(updatedUser.client_secret);
       this.clientSecret = updatedUser.client_secret;
     },
     async onLogout() {

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -18,14 +18,13 @@
         ]" />
       <CredentialsBox
         :header="'Credentials'"
-        :content= credentialsContent
+        :clientId="user.clientId"
+        :clientSecret="secretValue"
         data-test="credentials"
         :key="showSecretValue"
-        @toggle= this.ontoggleSecret
+        @display-secret= this.ontoggleSecret
+        @generateSecret = this.generateSecret
         />
-      <button @click="generateSecret" type="submit">
-        Generate Secret
-      </button>
     </app-content>
   </div>
 </template>
@@ -65,19 +64,20 @@ export default {
       ];
       return content;
     },
+
     secretValue() {
       if (this.showSecretValue) {
-        return [this.user.clientSecret];
+        return this.user.clientSecret;
       }
       if (this.user.clientSecret) {
-        return ['<click to show>'];
+        return '<click to show>';
       }
 
-      return ['<empty>'];
+      return '<empty>';
     },
   },
   methods: {
-    async generateSecret() {
+    async onGenerateSecret() {
       await authStore.generateSecret();
     },
     async onLogout() {

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -24,6 +24,7 @@
         :key="showSecretValue"
         @display-secret= this.onToggleSecret
         @generateSecret = this.onGenerateSecret
+        :onSecretGenerated="updateSecretValue"
         />
     </app-content>
   </div>
@@ -47,7 +48,11 @@ export default {
   data() {
     return {
       showSecretValue: false,
+      clientSecret: '',
     };
+  },
+  created() {
+    this.clientSecret = this.user.clientSecret;
   },
   computed: {
     user() {
@@ -67,9 +72,9 @@ export default {
 
     secretValue() {
       if (this.showSecretValue) {
-        return this.user.clientSecret;
+        return this.clientSecret;
       }
-      if (this.user.clientSecret) {
+      if (this.clientSecret) {
         return '<click to show>';
       }
 
@@ -79,6 +84,10 @@ export default {
   methods: {
     async onGenerateSecret() {
       await authStore.generateSecret();
+      const updatedUser = await authStore.getAPICredentials();
+      console.log(updatedUser)
+      console.log(updatedUser.client_secret)
+      this.clientSecret = updatedUser.client_secret;
     },
     async onLogout() {
       this.$router.push({path: '/rosalution/logout'});
@@ -87,6 +96,9 @@ export default {
       if (!this.showSecretValue && this.secretValue !== '<empty>') {
         this.showSecretValue = !this.showSecretValue;
       }
+    },
+    updateSecretValue() {
+      this.showSecretValue = true;
     },
   },
 };

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -22,8 +22,8 @@
         :clientSecret="secretValue"
         data-test="credentials"
         :key="showSecretValue"
-        @display-secret= this.ontoggleSecret
-        @generateSecret = this.generateSecret
+        @display-secret= this.onToggleSecret
+        @generateSecret = this.onGenerateSecret
         />
     </app-content>
   </div>
@@ -83,8 +83,8 @@ export default {
     async onLogout() {
       this.$router.push({path: '/rosalution/logout'});
     },
-    async ontoggleSecret() {
-      if (!this.showSecretValue && this.secretValue[0] !== '<empty>') {
+    async onToggleSecret() {
+      if (!this.showSecretValue && this.secretValue !== '<empty>') {
         this.showSecretValue = !this.showSecretValue;
       }
     },

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -83,7 +83,7 @@ export default {
     },
     async onToggleSecret() {
       if (!this.showSecretValue && this.secretValue !== '<empty>') {
-        this.showSecretValue = !this.showSecretValue;
+        this.showSecretValue = true;
       }
     },
     updateSecretValue() {

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -24,7 +24,7 @@
         :key="showSecretValue"
         @display-secret= this.onToggleSecret
         @generate-secret = this.onGenerateSecret
-        :onSecretGenerated="updateSecretValue"
+        :secretExists="clientSecretExists"
         />
     </app-content>
   </div>
@@ -67,6 +67,9 @@ export default {
       }
 
       return '<empty>';
+    },
+    clientSecretExists() {
+      return !!this.clientSecret;
     },
   },
   methods: {

--- a/frontend/test/components/AccountView/CredentialsBox.spec.js
+++ b/frontend/test/components/AccountView/CredentialsBox.spec.js
@@ -1,7 +1,6 @@
-import {expect, describe, it, beforeEach, afterEach} from 'vitest';
+import {expect, describe, it} from 'vitest';
 import {shallowMount} from '@vue/test-utils';
 import CredentialsBox from '@/components/AccountView/CredentialsBox.vue';
-import sinon from 'sinon';
 
 /**
  * helper function that shallow mounts and returns the rendered component
@@ -22,31 +21,18 @@ function getMountedComponent(props) {
 }
 
 describe('CredentialsBox.vue', () => {
-  let displaySecretSpy;
-  let generateSecretSpy;
-
-  beforeEach(() => {
-    displaySecretSpy = sinon.spy(CredentialsBox.methods, 'displaySecret');
-    generateSecretSpy = sinon.spy(CredentialsBox.methods, 'generateSecret');
-  });
-
-  afterEach(() => {
-    displaySecretSpy.restore();
-    generateSecretSpy.restore();
-  });
-
   it('renders the header prop', () => {
     const header = 'Test Header';
     const wrapper = getMountedComponent({header});
 
-    expect(wrapper.find('.credentials-name').text()).toContain(header);
+    expect(wrapper.find('.credentials-name').text()).to.contain(header);
   });
 
   it('renders the clientId prop', () => {
     const clientId = 'test-client-id';
     const wrapper = getMountedComponent({clientId});
 
-    expect(wrapper.find('[data-test="client-id-value-row"]').text()).toContain(clientId);
+    expect(wrapper.find('[data-test="client-id-value-row"]').text()).to.contain(clientId);
   });
 
   it('emits display-secret event when clientSecret is clicked', async () => {
@@ -54,13 +40,15 @@ describe('CredentialsBox.vue', () => {
     const wrapper = getMountedComponent({clientSecret});
 
     await wrapper.find('.clickable-text').trigger('click');
-    expect(displaySecretSpy.calledOnce).toBe(true);
+    expect(wrapper.emitted()).to.have.property('display-secret');
+    expect(wrapper.emitted()['display-secret']).to.have.length(1);
   });
 
   it('emits generateSecret event when Generate Secret button is clicked', async () => {
     const wrapper = getMountedComponent();
 
     await wrapper.find('.button').trigger('click');
-    expect(generateSecretSpy.calledOnce).toBe(true);
+    expect(wrapper.emitted()).to.have.property('generate-secret');
+    expect(wrapper.emitted()['generate-secret']).to.have.length(1);
   });
 });

--- a/frontend/test/components/AccountView/CredentialsBox.spec.js
+++ b/frontend/test/components/AccountView/CredentialsBox.spec.js
@@ -1,0 +1,66 @@
+import {expect, describe, it, beforeEach, afterEach} from 'vitest';
+import {shallowMount} from '@vue/test-utils';
+import CredentialsBox from '@/components/AccountView/CredentialsBox.vue';
+import sinon from 'sinon';
+
+/**
+ * helper function that shallow mounts and returns the rendered component
+ * @param {props} props props for testing to overwrite default props
+ * @return {VueWrapper} returns a shallow mounted using props
+ */
+function getMountedComponent(props) {
+  const defaultProps = {
+    header: '',
+    clientId: '',
+    clientSecret: '',
+    content: [],
+  };
+
+  return shallowMount(CredentialsBox, {
+    props: {...defaultProps, ...props},
+  });
+}
+
+describe('CredentialsBox.vue', () => {
+  let displaySecretSpy;
+  let generateSecretSpy;
+
+  beforeEach(() => {
+    displaySecretSpy = sinon.spy(CredentialsBox.methods, 'displaySecret');
+    generateSecretSpy = sinon.spy(CredentialsBox.methods, 'generateSecret');
+  });
+
+  afterEach(() => {
+    displaySecretSpy.restore();
+    generateSecretSpy.restore();
+  });
+
+  it('renders the header prop', () => {
+    const header = 'Test Header';
+    const wrapper = getMountedComponent({header});
+
+    expect(wrapper.find('.credentials-name').text()).toContain(header);
+  });
+
+  it('renders the clientId prop', () => {
+    const clientId = 'test-client-id';
+    const wrapper = getMountedComponent({clientId});
+
+    expect(wrapper.find('[data-test="client-id-value-row"]').text()).toContain(clientId);
+  });
+
+  it('emits display-secret event when clientSecret is clicked', async () => {
+    const clientSecret = 'test-client-secret';
+    const wrapper = getMountedComponent({clientSecret});
+
+    await wrapper.find('.clickable-text').trigger('click');
+    expect(displaySecretSpy.calledOnce).toBe(true);
+  });
+
+  it('emits generateSecret event when Generate Secret button is clicked', async () => {
+    const wrapper = getMountedComponent();
+
+    await wrapper.find('.button').trigger('click');
+    expect(generateSecretSpy.calledOnce).toBe(true);
+  });
+});

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -134,10 +134,10 @@ describe('AccountView.vue', () => {
   });
 
   it('should call onGenerateSecret method and update clientSecret', async () => {
-    getAPICredentialsStub.returns({ client_secret: 'newSecret' });
+    getAPICredentialsStub.returns({client_secret: 'newSecret'});
 
     const wrapper = getMountedComponent();
-    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    const credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
     await credentialsBox.vm.$emit('generateSecret');
     await wrapper.vm.$nextTick();
@@ -154,11 +154,11 @@ describe('AccountView.vue', () => {
   });
 
   it('should update clientSecret on multiple generateSecret calls', async () => {
-    getAPICredentialsStub.onFirstCall().returns({ client_secret: 'newSecret1' });
-    getAPICredentialsStub.onSecondCall().returns({ client_secret: 'newSecret2' });
+    getAPICredentialsStub.onFirstCall().returns({client_secret: 'newSecret1'});
+    getAPICredentialsStub.onSecondCall().returns({client_secret: 'newSecret2'});
 
     const wrapper = getMountedComponent();
-    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    const credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
     await credentialsBox.vm.$emit('generateSecret');
     await wrapper.vm.$nextTick();

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -85,11 +85,11 @@ describe('AccountView.vue', () => {
 
     let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
-    await credentialsBox.trigger('click');
+    await credentialsBox.vm.$emit('display-secret');
     await wrapper.vm.$nextTick();
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
+    expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.user.clientSecret);
   });
 
   it('should not toggle the secret value on click again after it has been toggled', async () => {
@@ -97,20 +97,20 @@ describe('AccountView.vue', () => {
 
     let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
-    await credentialsBox.trigger('click');
+    await credentialsBox.vm.$emit('display-secret');
     await wrapper.vm.$nextTick();
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
-    await credentialsBox.trigger('click');
+    expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.user.clientSecret);
+    await credentialsBox.vm.$emit('display-secret');
     await wrapper.vm.$nextTick();
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
+    expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.user.clientSecret);
   });
 
 
-  it('should return ["<empty>"] when user.client_secret is not set', () => {
+  it('should return "<empty>" when user.client_secret is not set', () => {
     sandbox.restore();
     sandbox = sinon.createSandbox();
     mockUser = {
@@ -125,6 +125,6 @@ describe('AccountView.vue', () => {
     let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('content')[1].value).toEqual(['<empty>']);
+    expect(credentialsBox.props('clientSecret')).toEqual('<empty>');
   });
 });

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -94,7 +94,7 @@ describe('AccountView.vue', () => {
     await wrapper.vm.$nextTick();
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.clientSecret);
+    expect(credentialsBox.props('clientSecret')).to.equal(wrapper.vm.clientSecret);
   });
 
   it('should not toggle the secret value on click again after it has been toggled', async () => {
@@ -106,12 +106,12 @@ describe('AccountView.vue', () => {
     await wrapper.vm.$nextTick();
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.clientSecret);
+    expect(credentialsBox.props('clientSecret')).to.equal(wrapper.vm.clientSecret);
     await credentialsBox.vm.$emit('display-secret');
     await wrapper.vm.$nextTick();
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.clientSecret);
+    expect(credentialsBox.props('clientSecret')).to.equal(wrapper.vm.clientSecret);
   });
 
   it('should call onGenerateSecret method and update clientSecret', async () => {
@@ -181,6 +181,6 @@ describe('AccountView.vue', () => {
     let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
     credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('clientSecret')).toEqual('<empty>');
+    expect(credentialsBox.props('clientSecret')).to.equal('<empty>');
   });
 });

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -143,7 +143,7 @@ describe('AccountView.vue', () => {
     expect(credentialsBox.props('clientSecret')).to.equal('<click to show>');
 
     await credentialsBox.vm.$emit('generate-secret');
-    await credentialsBox.vm.$emit('display-secret')
+    await credentialsBox.vm.$emit('display-secret');
     await wrapper.vm.$nextTick();
     expect(generateSecretStub.calledOnce).to.be.true;
     credentialsBox = wrapper.findComponent('[data-test=credentials]');

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -83,30 +83,30 @@ describe('AccountView.vue', () => {
   it('should toggle the secret value on click', async () => {
     const wrapper = getMountedComponent();
 
-    let sectionBox = wrapper.findComponent('[data-test=credentials]');
+    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
-    await sectionBox.trigger('click');
+    await credentialsBox.trigger('click');
     await wrapper.vm.$nextTick();
 
-    sectionBox = wrapper.findComponent('[data-test=credentials]');
-    expect(sectionBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
   });
 
   it('should not toggle the secret value on click again after it has been toggled', async () => {
     const wrapper = getMountedComponent();
 
-    let sectionBox = wrapper.findComponent('[data-test=credentials]');
+    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
-    await sectionBox.trigger('click');
+    await credentialsBox.trigger('click');
     await wrapper.vm.$nextTick();
 
-    sectionBox = wrapper.findComponent('[data-test=credentials]');
-    expect(sectionBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
-    await sectionBox.trigger('click');
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
+    await credentialsBox.trigger('click');
     await wrapper.vm.$nextTick();
 
-    sectionBox = wrapper.findComponent('[data-test=credentials]');
-    expect(sectionBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('content')[1].value).toEqual([wrapper.vm.user.clientSecret]);
   });
 
 
@@ -122,9 +122,9 @@ describe('AccountView.vue', () => {
 
     const wrapper = getMountedComponent();
 
-    let sectionBox = wrapper.findComponent('[data-test=credentials]');
+    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
 
-    sectionBox = wrapper.findComponent('[data-test=credentials]');
-    expect(sectionBox.props('content')[1].value).toEqual(['<empty>']);
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('content')[1].value).toEqual(['<empty>']);
   });
 });

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -134,30 +134,27 @@ describe('AccountView.vue', () => {
     expect(credentialsBox.props('clientSecret')).to.equal('updatedSecret');
   });
 
-  it('should update showSecretValue to true when updateSecretValue is called', () => {
-    const wrapper = getMountedComponent();
-    wrapper.vm.updateSecretValue();
-    expect(wrapper.vm.showSecretValue).to.be.true;
-  });
-
-  it('should update clientSecret on multiple generateSecret calls', async () => {
+  it('should update clientSecret on multiple generate-secret calls', async () => {
     getAPICredentialsStub.onFirstCall().returns({client_secret: 'newSecret1'});
     getAPICredentialsStub.onSecondCall().returns({client_secret: 'newSecret2'});
 
     const wrapper = getMountedComponent();
-    const credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('clientSecret')).to.equal('<click to show>');
 
-    await credentialsBox.vm.$emit('generateSecret');
+    await credentialsBox.vm.$emit('generate-secret');
+    await credentialsBox.vm.$emit('display-secret')
     await wrapper.vm.$nextTick();
     expect(generateSecretStub.calledOnce).to.be.true;
-    expect(getAPICredentialsStub.calledOnce).to.be.true;
-    expect(wrapper.vm.clientSecret).to.equal('newSecret1');
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('clientSecret')).to.equal('newSecret1');
 
-    await credentialsBox.vm.$emit('generateSecret');
+    await credentialsBox.vm.$emit('generate-secret');
+    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     expect(generateSecretStub.calledTwice).to.be.true;
-    expect(getAPICredentialsStub.calledTwice).to.be.true;
-    expect(wrapper.vm.clientSecret).to.equal('newSecret2');
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('clientSecret')).to.equal('newSecret2');
   });
 
   it('should initially hide the secret value in the CredentialsBox component', () => {

--- a/frontend/test/views/AccountView.spec.js
+++ b/frontend/test/views/AccountView.spec.js
@@ -114,25 +114,6 @@ describe('AccountView.vue', () => {
     expect(credentialsBox.props('clientSecret')).toEqual(wrapper.vm.clientSecret);
   });
 
-
-  it('should return "<empty>" when user.client_secret is not set', () => {
-    sandbox.restore();
-    sandbox = sinon.createSandbox();
-    mockUser = {
-      clientSecret: '',
-    };
-
-    const getUserEmptyStub = sandbox.stub(authStore, 'getUser');
-    getUserEmptyStub.returns(mockUser);
-
-    const wrapper = getMountedComponent();
-
-    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
-
-    credentialsBox = wrapper.findComponent('[data-test=credentials]');
-    expect(credentialsBox.props('clientSecret')).toEqual('<empty>');
-  });
-
   it('should call onGenerateSecret method and update clientSecret', async () => {
     getAPICredentialsStub.returns({client_secret: 'newSecret'});
 
@@ -183,5 +164,23 @@ describe('AccountView.vue', () => {
     const wrapper = getMountedComponent();
     wrapper.vm.showSecretValue = false;
     expect(wrapper.vm.secretValue).to.equal('<click to show>');
+  });
+
+  it('should return "<empty>" when user.client_secret is not set', () => {
+    sandbox.restore();
+    sandbox = sinon.createSandbox();
+    mockUser = {
+      clientSecret: '',
+    };
+
+    const getUserEmptyStub = sandbox.stub(authStore, 'getUser');
+    getUserEmptyStub.returns(mockUser);
+
+    const wrapper = getMountedComponent();
+
+    let credentialsBox = wrapper.findComponent('[data-test=credentials]');
+
+    credentialsBox = wrapper.findComponent('[data-test=credentials]');
+    expect(credentialsBox.props('clientSecret')).toEqual('<empty>');
   });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

- [The Generate Secret button will call the endpoint that generates the client_secret key and unhide it for the user](https://www.wrike.com/open.htm?id=1040376425)

Changes made:

- Created a new vue component called CredentialsBox.vue
- Created a new component test to test the CredentialsBox component.
- Refactored AccountView to make use of the new CredentialsBox Component.
- Refactored AccountView Unit Tests to account for the refactoring of AccountVue.

**To Review:**

- [x] Static Analysis by Reviewer
- [x] start from a clean development installation of Rosalution and login as a user
  ``` bash
    # From root of rosalution
    docker compose down
    docker system prune -a --volumes
    docker compose up --build -d
  ```
  - Navigate to [local.rosalution.cgds/rosalution](local.rosalution.cgds/rosalution)
  - login as a user
  - Click on the username in the header to go to the account view
![image](https://user-images.githubusercontent.com/4248757/225352374-884a4b63-ac23-43a7-8517-b50f757ddff6.png)

- [x] Verify the Credential box is rendering
   -  Verify that the Client ID is shown in the credentials box
   -  Verify that the Client Secret shows " < empty > "
![image](https://user-images.githubusercontent.com/4248757/225352568-f28849d8-d739-4501-95dd-9be1e6a29d00.png)

   -  Click on generate secret
   - Verify that the Client Secret is now showing the generated client secret.
![image](https://user-images.githubusercontent.com/4248757/225379540-bc63e0e2-1d53-4911-afba-1f2cb4a5b9bd.png)

   - Reload the page :arrows_counterclockwise:
   - Verify that the Client Secret now shows " < click to show > " as a secret value is already generated.
![image](https://user-images.githubusercontent.com/4248757/225354391-e92d964f-ff8b-4d65-8762-6946d939e022.png)

   - Verify that clicking on the " < click to show > " will then show the generated client secret.
![image](https://user-images.githubusercontent.com/4248757/225379678-c8232080-6ded-463f-8194-c00745f8b959.png)

  - verify that clicking on generate secret button again will update the client secret to a new value
![image](https://user-images.githubusercontent.com/4248757/225381169-51a7d8bb-2555-4d2c-9bd3-cc6ff6f1ff78.png)


- [x] All Github Actions checks have passed.

