### PR TITLE
Added Mark Ready and Mark Active conditions to analysis actions

### DIFF
--- a/frontend/src/components/DropDownMenu.vue
+++ b/frontend/src/components/DropDownMenu.vue
@@ -18,7 +18,7 @@ export default {
     actions: {
       type: Array,
       validator: (prop) => prop.every(
-          (action) => action.text !== undefined,
+          (action) => action.text !== undefined || action.divider,
       ),
     },
   },

--- a/frontend/src/models/analyses.js
+++ b/frontend/src/models/analyses.js
@@ -25,6 +25,18 @@ export default {
     return await Requests.put(url, updatedSections);
   },
 
+  async markAnalysisReady(analysisName) {
+    const url = `/rosalution/api/analysis/${analysisName}/mark_ready`;
+    return await Requests.put(url);
+  },
+
+  async markAnalysisActive(analysisName) {
+    // const url = `/rosalution/api/analysis/${analysisName}/mark_active`;
+    // return await Requests.put(url);
+    console.warn('Mark analysis active does not exist yet');
+    //  ** Not implemented yet **
+  },
+
   async getAnnotationConfiguration(analysisName) {
     // const baseUrl = '/rosalution/api/';
     // const urlQuery = `analysis/{analysisName}`;

--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -85,12 +85,6 @@ export default {
       store: authStore,
       analysis: {sections: []},
       updatedContent: {},
-      menuActions: [
-        {icon: 'pencil', text: 'Edit', operation: () => {
-          this.edit = !this.edit;
-        }, divider: true},
-        {icon: 'paperclip', text: 'Attach', operation: this.addSupportingEvidence},
-      ],
       edit: false,
       forceRenderComponentKey: 0,
     };
@@ -106,6 +100,41 @@ export default {
       sections.push('Supporting Evidence');
       return sections;
     },
+
+    menuActions() {
+      const actionChoices = [];
+
+      actionChoices.push(
+          {icon: 'pencil', text: 'Edit', operation: () => {
+            this.edit = !this.edit;
+          }},
+      );
+
+      if (this.analysis.latest_status === 'Annotation') {
+        actionChoices.push(
+            {icon: 'clipboard-check', text: 'Mark Ready', operation: () => {
+              Analyses.markAnalysisReady(this.analysis_name);
+            }},
+        );
+      }
+
+      if (this.analysis.latest_status === 'Ready') {
+        actionChoices.push(
+            {icon: 'book-open', text: 'Mark Active', operation: () => {
+              Analyses.markAnalysisActive(this.analysis_name);
+            }},
+        );
+      }
+
+      actionChoices.push({divider: true});
+
+      actionChoices.push(
+          {icon: 'paperclip', text: 'Attach', operation: this.addSupportingEvidence},
+      );
+
+      return actionChoices;
+    },
+
     sectionsList() {
       return this.analysis.sections;
     },

--- a/frontend/test/models/analyses.spec.js
+++ b/frontend/test/models/analyses.spec.js
@@ -10,12 +10,14 @@ describe('analyses.js', () => {
   let mockPostFormResponse;
   let mockPutFormResponse;
   let mockDeleteRequest;
+  let mockPutRequest;
 
   beforeEach(() => {
     mockGetRequest = sandbox.stub(Requests, 'get');
     mockPostFormResponse = sandbox.stub(Requests, 'postForm');
     mockPutFormResponse = sandbox.stub(Requests, 'putForm');
     mockDeleteRequest = sandbox.stub(Requests, 'delete');
+    mockPutRequest = sandbox.stub(Requests, 'put');
   });
 
   afterEach(() => {
@@ -41,6 +43,17 @@ describe('analyses.js', () => {
     mockPostFormResponse.returns({sucess: 'yay'});
     await Analyses.importPhenotipsAnalysis(incomingCreateAnalysisFormFixture);
     expect(mockPostFormResponse.called).to.be.true;
+  });
+
+  it('Marks an analysis ready', async () => {
+    await Analyses.markAnalysisReady('anything');
+    expect(mockPutRequest.called).to.be.true;
+  });
+
+  // Remove skip when mark active is added in API
+  it.skip('Marks an analysis active', async () => {
+    await Analyses.markAnalysisActive('anything');
+    expect(mockPutRequest.called).to.be.true;
   });
 
   describe('supporting evidence', () => {

--- a/frontend/test/models/analyses.spec.js
+++ b/frontend/test/models/analyses.spec.js
@@ -46,13 +46,13 @@ describe('analyses.js', () => {
   });
 
   it('Marks an analysis ready', async () => {
-    await Analyses.markAnalysisReady('anything');
+    await Analyses.markAnalysisReady('CPAM0002');
     expect(mockPutRequest.called).to.be.true;
   });
 
   // Remove skip when mark active is added in API
   it.skip('Marks an analysis active', async () => {
-    await Analyses.markAnalysisActive('anything');
+    await Analyses.markAnalysisActive('CPAM0002');
     expect(mockPutRequest.called).to.be.true;
   });
 

--- a/frontend/test/views/AnalysisView.spec.js
+++ b/frontend/test/views/AnalysisView.spec.js
@@ -23,7 +23,6 @@ import {RouterLink} from 'vue-router';
  */
 function getMountedComponent(props) {
   const defaultProps = {analysis_name: 'CPAM0046'};
-
   return shallowMount(AnalysisView, {
     props: {...defaultProps, ...props},
     global: {
@@ -50,6 +49,8 @@ describe('AnalysisView', () => {
   let pedigreeRemoveMock;
   let mockedAttachSupportingEvidence;
   let mockedRemoveSupportingEvidence;
+  let markReadyMock;
+  let markActiveMock;
   let wrapper;
   let sandbox;
 
@@ -64,6 +65,9 @@ describe('AnalysisView', () => {
 
     mockedAttachSupportingEvidence = sandbox.stub(Analyses, 'attachSupportingEvidence');
     mockedRemoveSupportingEvidence = sandbox.stub(Analyses, 'removeSupportingEvidence');
+
+    markReadyMock = sandbox.stub(Analyses, 'markAnalysisReady');
+    markActiveMock = sandbox.stub(Analyses, 'markAnalysisActive');
 
     wrapper = getMountedComponent();
   });
@@ -98,6 +102,42 @@ describe('AnalysisView', () => {
       expect(headerComponent.attributes('sectionanchors')).to.equal(
           'Brief,Medical Summary,Pedigree,Case Information,Supporting Evidence',
       );
+    });
+
+    it('should mark an analysis as ready', async () => {
+      const annotatingAnalysis = fixtureData();
+      annotatingAnalysis.latest_status = 'Annotation';
+      mockedData.returns(annotatingAnalysis);
+      const wrapper = getMountedComponent();
+      await wrapper.vm.$nextTick();
+      const headerComponent = wrapper.getComponent(
+          '[data-test=analysis-view-header]',
+      );
+      const actionsProps = headerComponent.props('actions');
+      for (const action of actionsProps) {
+        if (action.text === 'Mark Ready') {
+          action.operation();
+        }
+      }
+      expect(markReadyMock.called).to.be.true;
+    });
+
+    it('should mark an analysis as active', async () => {
+      const readyAnalysis = fixtureData();
+      readyAnalysis.latest_status = 'Ready';
+      mockedData.returns(readyAnalysis);
+      wrapper = getMountedComponent();
+      await wrapper.vm.$nextTick();
+      const headerComponent = wrapper.getComponent(
+          '[data-test=analysis-view-header]',
+      );
+      const actionsProps = headerComponent.props('actions');
+      for (const action of actionsProps) {
+        if (action.text === 'Mark Active') {
+          action.operation();
+        }
+      }
+      expect(markActiveMock.called).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

Issue Number 53 - [Enable Users to update an analysis' status to Ready or Active](https://github.com/uab-cgds-worthey/rosalution/issues/53)

Changes made:

- Added Mark Ready and Mark Active with a conditional based on the status
- Created placeholder for Mark Active, because I observed the endpoint did not exist
- Created tests for AnalysisView and AnalysesModel

**To Review:**
<!-- Make a to do list of things to check for to approve the pull request -->
<!-- Modify the below list as appropriate by editing and deleting text that is not applicable-->

- [x] Static Analysis by Reviewer
- [x] Upload new analysis case and mark as ready
  - Deploy application
```bash
docker compose up
```
  - Visit http://local.rosalution.cgds/rosalution/
  - Login as 'user01'
  - Import a new analysis, these can be found in ./etc/fixtures/import
  - Click uploaded analysis and mark as ready
 
![image](https://user-images.githubusercontent.com/6073669/228039478-eb752c80-7b06-4ef9-9a88-2f76a4d445da.png)

  - Go back to home page to see state changed

![image](https://user-images.githubusercontent.com/6073669/228039717-2aa97dc1-ed1a-4743-a12f-3c0566d76cb7.png)

  - Return to analysis to see Mark Active action

![image](https://user-images.githubusercontent.com/6073669/228040359-eaaddd23-820f-4b8f-85b4-c23de593351c.png)


- [x] All Github Actions checks have passed.
