### PR TITLE
Third party logo link on summary cards

### DIFF
--- a/backend/src/repository/analysis_collection.py
+++ b/backend/src/repository/analysis_collection.py
@@ -32,6 +32,8 @@ class AnalysisCollection:
             "genomic_units": 1,
             "nominated_by": 1,
             "timeline": 1,
+            "monday_com": 1,
+            "phenotips_com": 1,
         })
 
         summaries = []

--- a/frontend/src/components/AnalysisListing/AnalysisCard.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisCard.vue
@@ -248,11 +248,12 @@ div {
 .logo-link {
   display: inline-block;
   padding: 0 var(--p-1);
+  transform: translate(0, 20%);
 }
 
 .logo-link img {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
 }
 
 </style>

--- a/frontend/src/components/AnalysisListing/AnalysisCard.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisCard.vue
@@ -34,6 +34,16 @@
             </li>
           </ul>
         </div>
+        <div class="logo-links-section">
+            <a v-if="mondayLink" :href="mondayLink" target="_blank" class="logo-link"
+              data-test="monday-link" @click.stop>
+              <img src="/src/assets/monday-avatar-logo.svg" class="logo-img"/>
+            </a>
+            <a v-if="phenotipsLink" :href="phenotipsLink" target="_blank" class="logo-link"
+              data-test="phenotips-link" @click.stop>
+              <img src="/src/assets/phenotips-favicon-96x96.png" class="logo-img"/>
+            </a>
+          </div>
       </div>
     </div>
   </router-link>
@@ -68,6 +78,16 @@ export default {
     },
     genomic_units: {
       type: Array,
+    },
+    mondayLink: {
+      type: String,
+      default: '',
+      required: false,
+    },
+    phenotipsLink: {
+      type: String,
+      default: '',
+      required: false,
     },
   },
   computed: {
@@ -149,6 +169,7 @@ div {
   box-sizing: border-box;
   color: inherit;
   transition: all .2s ease-in-out;
+  position: relative;
 }
 
 .subection-text {
@@ -212,6 +233,26 @@ div {
   padding: var(--p-1) var(--p-1) var(--p-1) var(--p-1);
   word-wrap: break-word;
   margin-bottom: var(--p-1);
+}
+.logo-links-section {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--p-1);
+  position: absolute;
+  bottom: var(--p-1);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.logo-link {
+  display: inline-block;
+  padding: 0 var(--p-1);
+}
+
+.logo-link img {
+  width: 32px;
+  height: 32px;
 }
 
 </style>

--- a/frontend/src/views/AnalysisListingView.vue
+++ b/frontend/src/views/AnalysisListingView.vue
@@ -21,6 +21,8 @@
       :latest_status="analysis.latest_status"
       :created_date="analysis.created_date"
       :last_modified_date="analysis.last_modified_date"
+      :mondayLink="analysis.monday_com"
+      :phenotipsLink="analysis.phenotips_com"
     />
   </app-content>
   <app-footer>

--- a/frontend/test/components/AnalysisListing/AnalysisCard.spec.js
+++ b/frontend/test/components/AnalysisListing/AnalysisCard.spec.js
@@ -25,6 +25,8 @@ function getMountedComponent(props) {
     latest_status: 'Approved',
     created_date: '2021-09-30',
     last_modified_date: '2021-10-01',
+    mondayLink: 'https://monday.com',
+    phenotipsLink: 'https://phenotips.org',
   };
 
   return shallowMount(AnalysisCard, {
@@ -101,6 +103,28 @@ describe('AnalysisCard.vue', () => {
       });
       const icon = wrapper.get('font-awesome-icon-stub');
       expect(icon.attributes().icon).to.equal(test.expected);
+    });
+  });
+
+  describe('third party logo links', () => {
+    it('should add logo links when provided', () => {
+      const wrapper = getMountedComponent();
+      const mondayLink = wrapper.get('[data-test="monday-link"]');
+      const phenotipsLink = wrapper.get('[data-test="phenotips-link"]');
+      expect(mondayLink.exists()).to.be.true;
+      expect(phenotipsLink.exists()).to.be.true;
+    });
+
+    it('should open the correct links in a new tab', () => {
+      const wrapper = getMountedComponent();
+      const mondayLink = wrapper.get('[data-test="monday-link"]');
+      const phenotipsLink = wrapper.get('[data-test="phenotips-link"]');
+
+      expect(mondayLink.attributes().href).to.equal('https://monday.com');
+      expect(phenotipsLink.attributes().href).to.equal('https://phenotips.org');
+
+      expect(mondayLink.attributes().target).to.equal('_blank');
+      expect(phenotipsLink.attributes().target).to.equal('_blank');
     });
   });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

[Analysis summary page](https://www.wrike.com/open.htm?id=1089167230)

Changes made:

- Added logic to display third-party logos and link out in new tabs if there is a third-party link attached to the analysis

**To Review:**

- [x] Static Analysis by Reviewer
- [x] Static Analysis by Reviewer
- [x] Attach a Monday.com link
  - start from a clean development installation of Rosalution and login as a user
  ``` bash
    # From root of rosalution
    docker compose down
    docker system prune -a --volumes
    docker compose up --build -d
  ```
  - Navigate to [local.rosalution.cgds/rosalution](local.rosalution.cgds/rosalution)
  - Login as a user
  - Click on any Analysis Card.
  - in the Analysis view hover over the vertical 3 dot menu and then click on Attach Monday.com
  ![image](https://user-images.githubusercontent.com/4248757/230643838-4f65fc56-5411-4572-a373-792dbee6754e.png)
  - Observe that a link modal opens up for you to input a link.
  ![image](https://user-images.githubusercontent.com/4248757/229219322-eb243712-5528-41f2-a6a8-b34b76728963.png)
  - Input any text/link and click Add
   ![image](https://user-images.githubusercontent.com/4248757/229219881-d0bda078-067d-422b-b4d4-b50f38a627eb.png)
  - Navigate back to the home page
  - Observer that the monday.com logo now appears at the bottom of the analysis card that you attached a monday.com link to
  ![image](https://user-images.githubusercontent.com/4248757/230691799-75a7f601-b63c-4ac8-9fef-219a1f449a4a.png)
  - Click on the monday.com logo on the card and observer that it opens up a new tab with the link


-  [x] Attach a PhenoTips link
  -  Repeat the same actions as above except use the Attach PhenoTips menu action. This can be done from the same Analysis that you used for observing attaching a Monday.com link.
- [x] All Github Actions checks have passed.

<!-- Delete below header if Screenshots are NOT included -->
### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4248757/230691521-7d190138-f6fe-4d91-9f13-a7c243cc687a.png)
