### PR TITLE
Bug Fix: Input Dialog Box File Input Drag & Drop Area is too small height in height

### DIFF
--- a/frontend/src/components/Dialogs/InputDialogAttachUrl.vue
+++ b/frontend/src/components/Dialogs/InputDialogAttachUrl.vue
@@ -66,7 +66,8 @@ export default {
 <style>
 
 .comments {
-  flex: 3 0 auto
+  flex: 3 0 auto;
+  height: 8rem;
 }
 
 </style>

--- a/frontend/src/components/Dialogs/InputDialogUploadFile.vue
+++ b/frontend/src/components/Dialogs/InputDialogUploadFile.vue
@@ -115,7 +115,7 @@ input[type=file]::file-selector-button {
 
 .drop-file-box-content {
   display: flex;
-  height: 100%;
+  height: 8rem;
   justify-content: center ;
   align-items: center;
   gap: var(--p-1);
@@ -132,7 +132,8 @@ input[type=file]::file-selector-button {
 }
 
 .comments {
-  flex: 3 0 auto
+  flex: 3 0 auto;
+  height: 8rem;
 }
 
 </style>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes

## Pull Request Details

[Bug Fix: Input Dialog Box File Input Drag & Drop Area is too small height in height](https://www.wrike.com/open.htm?id=1092987241)

Changes made:

- styled the drag & drop file box to have a more approprate

**To Review:**

- [x] Static Analysis by Reviewer
- [x] Check that the file drag and drop box has a more appropriate heightlink
  - start from a clean development installation of Rosalution and login as a user
  ``` bash
    # From root of rosalution
    docker compose down
    docker system prune -a --volumes
    docker compose up --build -d
  ```
  - Navigate to [local.rosalution.cgds/rosalution](local.rosalution.cgds/rosalution)
  - Login as a user
  - Click on any Analysis Card.
  - hover over the vertical 3 dot menu and click on Attach
  - switch over to the file attach section of the modal
  - observer the following
  ![image](https://user-images.githubusercontent.com/4248757/232118600-ad2648a8-e77b-451a-b173-f299fced9c83.png)

  
- [x] All GitHub Actions checks have passed.
