### PR TITLE
Css improvements sidebar and sizing

### DIFF
--- a/frontend/src/components/AnnotationView/ImagesDataset.vue
+++ b/frontend/src/components/AnnotationView/ImagesDataset.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-image">
+    <div>
         <SectionImage
             v-for="(sectionImage) in this.sectionImages"
             :key="sectionImage.id"

--- a/frontend/src/components/SectionImage.vue
+++ b/frontend/src/components/SectionImage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="image-row">
       <a :href="domId">
         <img class="section-image" :src="imageSrc" data-test="annotation-image"/>
       </a>
@@ -58,6 +58,18 @@ export default {
 </script>
 
 <style>
+
+.image-row {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  align-items: start;
+}
+
+.section-image {
+  width:100%;
+}
+
 .edit-icon {
   color: var(--rosalution-purple-300);
   background: none;

--- a/frontend/src/components/SectionImage.vue
+++ b/frontend/src/components/SectionImage.vue
@@ -1,6 +1,11 @@
 <template>
     <div>
+      <a :href="domId">
         <img class="section-image" :src="imageSrc" data-test="annotation-image"/>
+      </a>
+      <a href="#_" class="lightbox" :id="imageId">
+        <span :style="{backgroundImage: `url(${this.imageSrc})`}"></span>
+      </a>
         <button
           class="edit-icon"
           @click="$emit('update-annotation-image', imageId, dataSet, genomicType)"
@@ -28,6 +33,11 @@ export default {
     genomicType: {
       type: String,
       default: '',
+    },
+  },
+  computed: {
+    domId() {
+      return `#${this.imageId}`;
     },
   },
   data() {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -170,6 +170,42 @@ app-footer {
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
+
+/** LIGHTBOX MARKUP **/
+
+.lightbox {
+  display: none;
+
+  /* Overlay entire screen */
+  position: fixed;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  padding: 1em;
+
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.lightbox:target {
+  display: block;
+  outline: none;
+}
+
+.lightbox span {
+  /* Full width and height */
+  display: block;
+  width: 100%;
+  height: 100%;
+
+  /* Size and position background image */
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
 /** || Typography **/
 
 .title {

--- a/frontend/src/views/AnnotationView.vue
+++ b/frontend/src/views/AnnotationView.vue
@@ -298,6 +298,9 @@ app-header {
 
 .sidebar {
   position: sticky;
+  height: 90vh;
+  top: 4rem;
+  flex: 1 1 auto;
 }
 
 </style>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.

## Pull Request Details

Wrike Issue - [CSS improvements for fixing the annotation sidebar and row sizing](https://www.wrike.com/open.htm?id=1106354624)

- Fixed the sidebar to be sticky by setting a top value since it has a parent html element
- Adjusting image data set rows for section images so that they don't grow beyond the width of the browser page but will shrink when the page shrinks, doing this using flexbox

**To Review:**

- [x] Static Analysis by Reviewer
- [ ]  Attach several annotation images and observe the sidebar scrolling for any of the genomic unit annotations
  - start from a clean development installation of Rosalution and login as a user
  ```bash
  # From root of rosalution
  docker compose down
  docker system prune -a --volumes
  docker compose up --build -d
  ```
  - Navigate to [local.rosalution.cgds/rosalution](http://local.rosalution.cgds/rosalution)
  - Login as a user
  - Click on any Analysis Card that has genomic units in it
  - Choose any of the genes or variants and attach images
  - [x] If a big image, does it just fill the width?
  - [x] do the edit buttons stay in the top right of each row?
  - [x] Does the sidebar stay sticky and visible when scrolling down the page?
- [x] All Github Actions checks have passed.

### Screenshots (if appropriate)
<img width="893" alt="Screenshot 2023-05-01 at 4 08 06 PM" src="https://user-images.githubusercontent.com/1209059/235531619-3e054143-1ce4-43ea-99bd-ed4afa6fdda8.png">

