### PR TITLE
Toasts

### DIFF
--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -329,12 +329,12 @@ export default {
       this.updatedContent = {};
       this.edit=false;
       this.uptickSectionKeyToForceReRender();
-      toast.success('Analysis updated successfully.')
+      toast.success('Analysis updated successfully.');
     },
     cancelAnalysisChanges() {
       this.edit=false;
       this.updatedContent = {};
-      toast.info('Analysis changes cancelled.')
+      toast.info('Analysis changes cancelled.');
     },
     async onLogout() {
       this.$router.push({path: '/rosalution/logout'});

--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -404,7 +404,6 @@ export default {
         this.analysis = {...this.analysis, ...updatedAnalysis};
         toast.success('Analysis marked as ready.');
       } catch (error) {
-        console.error('Updating the analysis did not work', error);
         toast.error('Error marking analysis as ready.');
       }
     },

--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -11,6 +11,7 @@
           :third_party_links="analysis.third_party_links"
           data-test="analysis-view-header">
         </AnalysisViewHeader>
+        <Toast data-test="toast"/>
       </app-header>
       <app-content>
         <GeneBox
@@ -62,11 +63,13 @@ import SectionBox from '@/components/AnalysisView/SectionBox.vue';
 import GeneBox from '@/components/AnalysisView/GeneBox.vue';
 import InputDialog from '@/components/Dialogs/InputDialog.vue';
 import NotificationDialog from '@/components/Dialogs/NotificationDialog.vue';
+import Toast from '@/components/Dialogs/Toast.vue';
 import SupplementalFormList from '@/components/AnalysisView/SupplementalFormList.vue';
 import SaveModal from '@/components/AnalysisView/SaveModal.vue';
 
 import inputDialog from '@/inputDialog.js';
 import notificationDialog from '@/notificationDialog.js';
+import toast from '@/toast.js';
 
 import {authStore} from '@/stores/authStore.js';
 
@@ -78,6 +81,7 @@ export default {
     GeneBox,
     InputDialog,
     NotificationDialog,
+    Toast,
     SupplementalFormList,
     SaveModal,
   },
@@ -112,6 +116,7 @@ export default {
       actionChoices.push(
           {icon: 'pencil', text: 'Edit', operation: () => {
             this.edit = !this.edit;
+            toast.info('Edit mode enabled.');
           }},
       );
 
@@ -125,6 +130,7 @@ export default {
         actionChoices.push(
             {icon: 'book-open', text: 'Mark Active', operation: () => {
               Analyses.markAnalysisActive(this.analysis_name);
+              toast.info('This feature is not yet implemented.');
             }},
         );
       }
@@ -323,10 +329,12 @@ export default {
       this.updatedContent = {};
       this.edit=false;
       this.uptickSectionKeyToForceReRender();
+      toast.success('Analysis updated successfully.')
     },
     cancelAnalysisChanges() {
       this.edit=false;
       this.updatedContent = {};
+      toast.info('Analysis changes cancelled.')
     },
     async onLogout() {
       this.$router.push({path: '/rosalution/logout'});
@@ -394,8 +402,10 @@ export default {
       try {
         const updatedAnalysis = await Analyses.markAnalysisReady(this.analysis_name);
         this.analysis = {...this.analysis, ...updatedAnalysis};
+        toast.success('Analysis marked as ready.');
       } catch (error) {
         console.error('Updating the analysis did not work', error);
+        toast.error('Error marking analysis as ready.');
       }
     },
   },

--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -115,8 +115,12 @@ export default {
 
       actionChoices.push(
           {icon: 'pencil', text: 'Edit', operation: () => {
+            if (!this.edit) {
+              toast.info('Edit mode enabled.');
+            } else {
+              toast.info('Edit mode disabled.');
+            }
             this.edit = !this.edit;
-            toast.info('Edit mode enabled.');
           }},
       );
 
@@ -334,7 +338,7 @@ export default {
     cancelAnalysisChanges() {
       this.edit=false;
       this.updatedContent = {};
-      toast.info('Analysis changes cancelled.');
+      toast.info('Edit mode disabled.');
     },
     async onLogout() {
       this.$router.push({path: '/rosalution/logout'});

--- a/frontend/test/views/AnalysisView.spec.js
+++ b/frontend/test/views/AnalysisView.spec.js
@@ -112,7 +112,6 @@ describe('AnalysisView', () => {
     });
 
     describe('actions with toasts', () => {
-
       /**
        * Helper triggers an action based on the action text
        * @param {VueWrapper} wrapper The Vue wrapper containing the component instance
@@ -166,7 +165,7 @@ describe('AnalysisView', () => {
         const wrapper = await getMockedWrapper('Annotation');
         const error = new Error('Failed to mark analysis as ready');
         markReadyMock.throws(error);
-        
+
         try {
           await triggerAction(wrapper, 'Mark Ready');
         } catch (error) {
@@ -540,12 +539,12 @@ describe('AnalysisView', () => {
 
   describe('Saving and canceling analysis changes displays toasts', () => {
     beforeEach(() => {
-      updateAnalysisSectionsStub.returns(Promise.resolve({ sections: [] })); // return a resolved promise with mocked data
+      updateAnalysisSectionsStub.returns(Promise.resolve({sections: []})); // return a resolved promise with mocked data
     });
 
     it('should display success toast when saving analysis changes', async () => {
       const wrapper = getMountedComponent();
-      await wrapper.setData({ edit: true });
+      await wrapper.setData({edit: true});
       const saveModal = wrapper.findComponent(SaveModal);
 
       saveModal.vm.$emit('save');
@@ -558,7 +557,7 @@ describe('AnalysisView', () => {
 
     it('should display info toast when canceling analysis changes', async () => {
       const wrapper = getMountedComponent();
-      await wrapper.setData({ edit: true });
+      await wrapper.setData({edit: true});
       const saveModal = wrapper.findComponent(SaveModal);
 
       saveModal.vm.$emit('canceledit');

--- a/frontend/test/views/AnalysisView.spec.js
+++ b/frontend/test/views/AnalysisView.spec.js
@@ -203,6 +203,15 @@ describe('AnalysisView', () => {
         expect(toast.state.type).to.equal('info');
         expect(toast.state.message).to.equal('Edit mode enabled.');
       });
+      it('should display info toast with correct message when exiting edit mode', async () => {
+        const wrapper = getMountedComponent();
+        await wrapper.setData({edit: true});
+        await triggerAction(wrapper, 'Edit');
+
+        expect(toast.state.active).to.be.true;
+        expect(toast.state.type).to.equal('info');
+        expect(toast.state.message).to.equal('Edit mode disabled.');
+      });
     });
   });
 
@@ -565,7 +574,7 @@ describe('AnalysisView', () => {
 
       expect(toast.state.active).to.be.true;
       expect(toast.state.type).to.equal('info');
-      expect(toast.state.message).to.equal('Analysis changes cancelled.');
+      expect(toast.state.message).to.equal('Edit mode disabled.');
     });
   });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

[As a user, I need visual confirmation of completing operations in Rosalution to know if they succeeded or failed.](https://www.wrike.com/open.htm?id=1108022419)

Changes made:

- Added toasts for the following:
  - Editing an analysis
  - Saving an analysis
  - Changing the status of a case
    - Mark Ready (Succeed or Error)
    - Mark Active (Info - because active is not implemented yet on the backend)


**To Review:**


- [ ] Static Analysis by Reviewer
- [ ] Visually verify toasts
   1. Deploy Rosalution
    ``` bash
    # From the root of rosalution
    docker-compose down
    docker system prune -a --volumes
    docker-compose up --build -d
    ```
   2. Login as a user.
   3. Upload a new case
   4. Navigate to that new case
   5. Enable Editing and observe that the toast is displayed
   ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/ae1ef5be-8848-43bd-9135-988cc8602266)
   6. Disable Editing mode via the menu action and observer that the new toast is displayed
   ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/02f80961-3b93-43b6-ad8f-476cecea9a68)
   7. Disable Editing mode via the cancel button in the modal down below will result in the same toast as above
   8. Saving changes from Editing mode via the save button in the modal down below will result in a toast notifying that the changes are saved. Observer the toast.
   ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/a07ac5b8-a22c-4430-8c76-6d1cc1e814eb)
   9. Marking the analysis as Ready via menu action and observe the success toast
   ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/74b3892b-03ac-4da6-9c0a-a7b2b57703c6)
     - note that there is an error toast for this action. however, I do not know how to trigger it from the browser, but it is tested & accounted for in the unit tests.
   10. Marking the analysis as Active via the menu action and observer the info toast, notifying that this feature is not yet implemented.
   ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/faf8539e-45fd-4d8b-abdf-d39c239707b3)

- [ ] All Github Actions checks have passed.