### PR TITLE
Same name supporting evidance

### DIFF
--- a/backend/src/repository/analysis_collection.py
+++ b/backend/src/repository/analysis_collection.py
@@ -131,10 +131,26 @@ class AnalysisCollection:
             return None
 
         for file in analysis['supporting_evidence_files']:
-            if file['filename'] == file_name:
+            if file['name'] == file_name:
                 return file
 
         return None
+
+    def file_exists_in_analysis(self, analysis_name: str, file_name: str):
+        """ Returns True if a file exists in an analysis by name """
+        analysis = self.collection.find_one({"name": analysis_name})
+
+        if not analysis:
+            return False
+
+        if 'supporting_evidence_files' not in analysis:
+            return False
+
+        for file in analysis['supporting_evidence_files']:
+            if file['name'] == file_name:
+                return True
+
+        return False
 
     def attach_supporting_evidence_file(self, analysis_name: str, file_id: str, filename: str, comments: str):
         """Attaches supporting evidence documents and comments for an analysis"""

--- a/backend/src/routers/analysis_router.py
+++ b/backend/src/routers/analysis_router.py
@@ -203,7 +203,8 @@ def remove_pedigree(analysis_name: str, repositories=Depends(database)):
 
 @router.post("/{analysis_name}/attach/file")
 def attach_supporting_evidence_file(
-    analysis_name: str, upload_file: UploadFile = File(...), comments: str = Form(...), repositories=Depends(database)):
+    analysis_name: str, upload_file: UploadFile = File(...), comments: str = Form(...), repositories=Depends(database)
+):
     """Uploads a file to GridFS and adds it to the analysis"""
     if repositories["analysis"].file_exists_in_analysis(analysis_name, upload_file.filename):
         raise HTTPException(status_code=409, detail="File with the same name already exists in the given analysis")
@@ -215,7 +216,6 @@ def attach_supporting_evidence_file(
     return repositories["analysis"].attach_supporting_evidence_file(
         analysis_name, new_file_object_id, upload_file.filename, comments
     )
-
 
 
 @router.post("/{analysis_name}/attach/link")

--- a/backend/src/routers/analysis_router.py
+++ b/backend/src/routers/analysis_router.py
@@ -149,7 +149,7 @@ def download(analysis_name: str, file_name: str, repositories=Depends(database))
     if not file:
         raise HTTPException(status_code=404, detail="File not found.")
 
-    return StreamingResponse(repositories['bucket'].stream_analysis_file_by_id(file['file_id']))
+    return StreamingResponse(repositories['bucket'].stream_analysis_file_by_id(file['attachment_id']))
 
 
 @router.post("/{analysis_name}/attach/pedigree", response_model=Section)
@@ -203,17 +203,19 @@ def remove_pedigree(analysis_name: str, repositories=Depends(database)):
 
 @router.post("/{analysis_name}/attach/file")
 def attach_supporting_evidence_file(
-    analysis_name: str, upload_file: UploadFile = File(...), comments: str = Form(...), repositories=Depends(database)
-):
+    analysis_name: str, upload_file: UploadFile = File(...), comments: str = Form(...), repositories=Depends(database)):
     """Uploads a file to GridFS and adds it to the analysis"""
-    if repositories['bucket'].filename_exists(upload_file.filename):
-        raise HTTPException(status_code=409, detail="File already exists in Rosalution")
+    if repositories["analysis"].file_exists_in_analysis(analysis_name, upload_file.filename):
+        raise HTTPException(status_code=409, detail="File with the same name already exists in the given analysis")
+
     new_file_object_id = repositories['bucket'].save_file(
         upload_file.file, upload_file.filename, upload_file.content_type
     )
+
     return repositories["analysis"].attach_supporting_evidence_file(
         analysis_name, new_file_object_id, upload_file.filename, comments
     )
+
 
 
 @router.post("/{analysis_name}/attach/link")

--- a/backend/tests/fixtures/analysis-CPAM0002.json
+++ b/backend/tests/fixtures/analysis-CPAM0002.json
@@ -165,7 +165,7 @@
   ],
   "supporting_evidence_files": [
     {
-      "filename": "test.txt", 
+      "name": "test.txt", 
       "attachment_id": "633afb87fb250a6ea1569555", 
       "comments": "hello world"
     }

--- a/backend/tests/fixtures/analysis-update.json
+++ b/backend/tests/fixtures/analysis-update.json
@@ -115,7 +115,7 @@
   ],
   "supporting_evidence_files": [
     {
-      "filename": "test.txt",
+      "name": "test.txt",
       "file_id": "633afb87fb250a6ea1569555",
       "comments": "This is a test comment for file test.txt"
     }

--- a/backend/tests/fixtures/empty-pedigree.json
+++ b/backend/tests/fixtures/empty-pedigree.json
@@ -158,7 +158,7 @@
     ],
     "supporting_evidence_files": [
         {
-            "filename": "test.txt",
+            "name": "test.txt",
             "attachment_id": "633afb87fb250a6ea1569555",
             "comments": "hello world"
         }

--- a/backend/tests/unit/repository/test_analysis_collection.py
+++ b/backend/tests/unit/repository/test_analysis_collection.py
@@ -133,6 +133,7 @@ def test_attach_file_supporting_evidence(analysis_collection, cpam0002_analysis_
     assert 'attachment_id' in new_evidence
     assert new_evidence['attachment_id'] == 'Fake-Mongo-Object-ID-2'
 
+
 def test_file_exists_in_analysis(analysis_collection):
     """Tests the file_exists_in_analysis function"""
     analysis_collection.collection.find_one.return_value = read_test_fixture("analysis-CPAM0002.json")

--- a/backend/tests/unit/repository/test_analysis_collection.py
+++ b/backend/tests/unit/repository/test_analysis_collection.py
@@ -44,7 +44,7 @@ def test_find_file_by_name(analysis_collection):
     """Tests the find_file_by_name function"""
     analysis_collection.collection.find_one.return_value = read_test_fixture("analysis-CPAM0002.json")
     actual = analysis_collection.find_file_by_name("CPAM0002", "test.txt")
-    assert actual == {'attachment_id': '633afb87fb250a6ea1569555', 'comments': 'hello world', 'filename': 'test.txt'}
+    assert actual == {'attachment_id': '633afb87fb250a6ea1569555', 'comments': 'hello world', 'name': 'test.txt'}
 
 
 def test_find_file_by_name_analysis_none(analysis_collection):
@@ -132,6 +132,12 @@ def test_attach_file_supporting_evidence(analysis_collection, cpam0002_analysis_
     assert new_evidence['type'] == 'file'
     assert 'attachment_id' in new_evidence
     assert new_evidence['attachment_id'] == 'Fake-Mongo-Object-ID-2'
+
+def test_file_exists_in_analysis(analysis_collection):
+    """Tests the file_exists_in_analysis function"""
+    analysis_collection.collection.find_one.return_value = read_test_fixture("analysis-CPAM0002.json")
+    actual = analysis_collection.file_exists_in_analysis("CPAM0002", "test.txt")
+    assert actual is True
 
 
 def test_add_pedigree_file(analysis_collection, empty_pedigree):

--- a/system-tests/e2e/case_supporting_evidence.cy.js
+++ b/system-tests/e2e/case_supporting_evidence.cy.js
@@ -150,4 +150,60 @@ describe('case_supporting_evidence.cy.js', () => {
     cy.get('[data-test="confirm-button"]').click();
     cy.get('.attachment-list').should('have.length', 0);
   });
+
+  it('should fail to attach the same supporting evidence file twice to the same analysis', () => {
+    cy.get('#Supporting_Evidence').should('exist');
+    cy.get('.attachment-list').should('have.length', 0);
+    cy.get('[data-test="add-button"]').click();
+    cy.get('[data-test="button-input-dialog-upload-file"]').click();
+    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+      action: 'drag-drop',
+    });
+    cy.get('.comments').type('this is a test comment for a test file');
+    cy.get('[data-test="confirm"]').click();
+    cy.get('[href="#Supporting_Evidence"]').click();
+    cy.get('.attachment-list').should('have.length', 1);
+    cy.get('.attachment-name > div').should('have.attr', 'target', '_blank');
+    cy.get('.attachment-name > div').should('have.attr', 'rel', 'noreferrer noopener');
+    cy.get('[data-test="add-button"]').click();
+    cy.get('[data-test="button-input-dialog-upload-file"]').click();
+    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+      action: 'drag-drop',
+    });
+    cy.get('.comments').type('this is a test comment for a test file');
+    cy.get('[data-test="confirm"]').click();
+    cy.get('.attachment-list').should('have.length', 1);
+  });
+
+  it('should be able to attach the same supporting evidence file to different analyses', () => {
+    cy.get('#Supporting_Evidence').should('exist');
+    cy.get('.attachment-list').should('have.length', 0);
+    cy.get('[data-test="add-button"]').click();
+    cy.get('[data-test="button-input-dialog-upload-file"]').click();
+    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+      action: 'drag-drop',
+    });
+    cy.get('.comments').type('this is a test comment for a test file');
+    cy.get('[data-test="confirm"]').click();
+    cy.get('[href="#Supporting_Evidence"]').click();
+    cy.get('.attachment-list').should('have.length', 1);
+    cy.get('.attachment-name > div').should('have.attr', 'target', '_blank');
+    cy.get('.attachment-name > div').should('have.attr', 'rel', 'noreferrer noopener');
+
+    cy.get('.rosalution-logo').click();
+    cy.get('[href="/rosalution/analysis/CPAM0046"] > .analysis-card > .analysis-base').click();
+    cy.get('[href="#Supporting_Evidence"]').click();
+    cy.get('.attachment-list').should('have.length', 0);
+    cy.get('[data-test="add-button"]').click();
+    cy.get('[data-test="button-input-dialog-upload-file"]').click();
+    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+      action: 'drag-drop',
+    });
+    cy.get('.comments').type('this is a test comment for a test file');
+    cy.get('[data-test="confirm"]').click();
+    cy.get('[href="#Supporting_Evidence"]').click();
+    cy.get('.attachment-list').should('have.length', 1);
+    cy.get('.attachment-name > div').should('have.attr', 'target', '_blank');
+    cy.get('.attachment-name > div').should('have.attr', 'rel', 'noreferrer noopener');
+  });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

[As a user, I want to upload supporting evidence files with identical names to different analyses' supporting evidence, So I can use them without conflicts or renaming.](https://www.wrike.com/open.htm?id=1110069274)

Changes made:

- Updated the `attach_supporting_evidence_file` function on the analysis_roter  to allow for uploading a file with the same name to a different analysis within rosalution.
- Added a function to the analysis_collection called `file_exists_in_analysis` in the backend that checks if a file with the filename exists in supporting evidence of an analysis. It returns a boolean response
- Added unit tests for this new function
- Made a change to the `find_file_by_name` function in the analysis_collection repository. 
  - This change restores functionality that was previously not working, even though tests were passing. The issue was that it was using an incorrect selector, `file['filename']`, that does not actually exist within our system. 
  - It is now properly accessed with the `file['name']` accessor.
  - with this change, tests were able to pass.
- Made a change to the logic for the API of `GET /{analysis_name}/download/{file_name}
  - This change restores the functionality of this route. It was previously using the incorrect selector of `file['file_id']` when it should have been using `file['attachment_id']`
- Updated the test fixtures to accurately represent the actual data that they are representing for testing.
- Added system tests to ensure that this functionality works as expected

**To Review:**

- [ ] Static Analysis by Reviewer
- [ ] Verify that you can upload a file to supporting evidence with that same name only once for the analysis
   1. Deploy Rosalution
    ``` bash
    # From the root of rosalution
    docker-compose down
    docker system prune -a --volumes
    docker-compose up --build -d
    ```
   2. Login as a user.
   3. Navigate to an analysis
   4. Upload a file to the supporting evidence section
   5. Once successfully uploaded, attempt to upload a file with the same name as the previous step to the supporting evidence.
   6. Verify that it did not upload that file again. In the console, you should see that a 409 error is returned.
- [ ] Verify that you can upload a file with the same name and supporting evidence to different analyses.
   1. Complete the above steps.
   2. Navigate to a different analysis
   3. Upload a file with the same name as the file you successfully uploaded to the system for supporting evidence.
   4. Observer that the system allowed you to upload the file even though it has the same name as the file in the other analysis' supporting evidence.
- [ ] All Github Actions checks have passed.
