### PR TITLE
Investigate why CPAM0084 breaks when re-running annotation from the api docs

### DIFF
--- a/backend/tests/unit/repository/test_genomic_unit_collection.py
+++ b/backend/tests/unit/repository/test_genomic_unit_collection.py
@@ -14,7 +14,7 @@ from ...test_utils import mock_mongo_collection, read_database_fixture
 def test_find_genomic_units(genomic_unit_collection):
     """ Gets all the genomic units from the genomic unit collection """
     all_genomic_units = genomic_unit_collection.all()
-    assert len(all_genomic_units) == 14
+    assert len(all_genomic_units) == 18
 
 
 def test_transcript_annotation_not_exist_with_no_annotations(genomic_unit_collection, hgvs_variant_genomic_unit_json):

--- a/etc/fixtures/initial-seed/genomic-units.json
+++ b/etc/fixtures/initial-seed/genomic-units.json
@@ -388,6 +388,1054 @@
 	]
 },
 {
+	"hgvs_variant": "NM_005249.5:c.924G>A",
+	"transcripts": [
+		{
+			"transcript_id": "NM_005249.5",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_005249.5"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"stop_gained"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				},
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_005249.5"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_026731.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_026731.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"upstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				},
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_026731.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_026732.1",
+			"annotations": [
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"upstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				},
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_026732.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_125758.1",
+			"annotations": [
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"upstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				},
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_125758.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"ClinVar_Variantion_Id": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "13871"
+				}
+			]
+		},
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": 37
+				}
+			]
+		},
+		{
+			"ClinVar_variant_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/13871"
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_005249.5:c.256dup",
+	"transcripts": [
+		{
+			"transcript_id": "NM_005249.5",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_005249.5"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_125758.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_125758.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"upstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": 25.2
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_170707.3:c.745C>T",
+	"transcripts": [
+		{
+			"transcript_id": "NM_001257374.3",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001257374.3"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.999
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001282624.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001282624.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 1
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001282625.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001282625.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 1
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001282626.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001282626.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 1
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_005572.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_005572.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 1
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_170707.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_170707.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 1
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_170708.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_170708.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.999
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"ClinVar_Variantion_Id": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "14524"
+				}
+			]
+		},
+		{
+			"ClinVar_Variantion_Id": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "14524"
+				}
+			]
+		},
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": 26.5
+				}
+			]
+		},
+		{
+			"ClinVar_variant_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/14524"
+				}
+			]
+		}
+	]
+},
+{
 	"hgvs_variant": "NM_002972.2:c.3493_3494dupTA",
 	"transcripts": [
 		{
@@ -527,6 +1575,2830 @@
 							"data_source": "Ensembl",
 							"version": "",
 							"value": "HIGH"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": null
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_153818.2:c.928C>G",
+	"transcripts": [
+		{
+			"transcript_id": "NM_001374425.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001374425.1"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001374426.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001374426.1"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001374427.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001374427.1"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_002617.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_002617.4"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.999
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_007033.5",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_007033.5"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_153818.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_153818.2"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.999
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "probably_damaging"
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_164636.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_164636.1"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"non_coding_transcript_exon_variant"
+							]
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"ClinVar_Variantion_Id": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "552930"
+				}
+			]
+		},
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": 27.4
+				}
+			]
+		},
+		{
+			"ClinVar_variant_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/552930"
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_153818.2:c.28dup",
+	"transcripts": [
+		{
+			"transcript_id": "NM_001374425.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001374425.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001374426.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001374426.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"intron_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001374427.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001374427.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"intron_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_002617.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_002617.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_153818.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_153818.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_164636.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_164636.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"intron_variant",
+								"non_coding_transcript_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": null
+				}
+			]
+		}
+	]
+},
+{
+	"gene_symbol": "PEX10",
+	"gene": "PEX10",
+	"annotations": [
+		{
+			"Entrez Gene Id": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": 5192
+				}
+			]
+		},
+		{
+			"Ensembl Gene Id": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "ENSG00000157911"
+				}
+			]
+		},
+		{
+			"NCBI_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=5192"
+				}
+			]
+		},
+		{
+			"gnomAD_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://gnomad.broadinstitute.org/gene/ENSG00000157911?dataset=gnomad_r2_1"
+				}
+			]
+		},
+		{
+			"OMIM_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.omim.org/search?index=entry&start=1&sort=score+desc%2C+prefix_sort+desc&search=PEX10"
+				}
+			]
+		},
+		{
+			"OMIM": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"Infantile Refsum Disease",
+						"Peroxisome Biogenesis Disorder 6a (zellweger)",
+						"Peroxisome Biogenesis Disorder 6b",
+						"Autosomal Recessive Ataxia Due To Pex10 Deficiency",
+						"Neonatal Adrenoleukodystrophy",
+						"Zellweger Syndrome"
+					]
+				}
+			]
+		},
+		{
+			"HPO": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"HP:0000952: Jaundice",
+						"HP:0000268: Dolichocephaly",
+						"HP:0000368: Low-set, posteriorly rotated ears",
+						"HP:0000028: Cryptorchidism",
+						"HP:0000256: Macrocephaly",
+						"HP:0000508: Ptosis",
+						"HP:0002078: Truncal ataxia",
+						"HP:0000252: Microcephaly",
+						"HP:0000286: Epicanthus",
+						"HP:0001508: Failure to thrive",
+						"HP:0009891: Underdeveloped supraorbital ridges",
+						"HP:0008167: Very long chain fatty acid accumulation",
+						"HP:0000218: High palate",
+						"HP:0001319: Neonatal hypotonia",
+						"HP:0002457: Abnormal head movements",
+						"HP:0011499: Mydriasis",
+						"HP:0000627: Posterior embryotoxon",
+						"HP:0001410: Decreased liver function",
+						"HP:0001939: Abnormality of metabolism/homeostasis",
+						"HP:0001761: Pes cavus",
+						"HP:0002652: Skeletal dysplasia",
+						"HP:0002353: EEG abnormality",
+						"HP:0000641: Dysmetric saccades",
+						"HP:0002024: Malabsorption",
+						"HP:0000407: Sensorineural hearing impairment",
+						"HP:0100543: Cognitive impairment",
+						"HP:0005469: Flat occiput",
+						"HP:0002269: Abnormality of neuronal migration",
+						"HP:0000369: Low-set ears",
+						"HP:0001260: Dysarthria",
+						"HP:0005978: Type II diabetes mellitus",
+						"HP:0007240: Progressive gait ataxia",
+						"HP:0007002: Motor axonal neuropathy",
+						"HP:0011344: Severe global developmental delay",
+						"HP:0002500: Abnormal cerebral white matter morphology",
+						"HP:0001257: Spasticity",
+						"HP:0005280: Depressed nasal bridge",
+						"HP:0002240: Hepatomegaly",
+						"HP:0000532: Abnormal chorioretinal morphology",
+						"HP:0000648: Optic atrophy",
+						"HP:0001265: Hyporeflexia",
+						"HP:0002080: Intention tremor",
+						"HP:0001638: Cardiomyopathy",
+						"HP:0012368: Flat face",
+						"HP:0008572: External ear malformation",
+						"HP:0001399: Hepatic failure",
+						"HP:0012736: Profound global developmental delay",
+						"HP:0000582: Upslanted palpebral fissure",
+						"HP:0000708: Behavioral abnormality",
+						"HP:0002073: Progressive cerebellar ataxia",
+						"HP:0000501: Glaucoma",
+						"HP:0001250: Seizure",
+						"HP:0001622: Premature birth",
+						"HP:0010655: Epiphyseal stippling",
+						"HP:0000556: Retinal dystrophy",
+						"HP:0000347: Micrognathia",
+						"HP:0000365: Hearing impairment",
+						"HP:0000007: Autosomal recessive inheritance",
+						"HP:0008935: Generalized neonatal hypotonia",
+						"HP:0000348: High forehead",
+						"HP:0001088: Brushfield spots",
+						"HP:0000003: Multicystic kidney dysplasia",
+						"HP:0008064: Ichthyosis",
+						"HP:0004322: Short stature",
+						"HP:0000260: Wide anterior fontanel",
+						"HP:0005930: Abnormality of epiphysis morphology",
+						"HP:0000463: Anteverted nares",
+						"HP:0001251: Ataxia",
+						"HP:0000639: Nystagmus",
+						"HP:0000518: Cataract",
+						"HP:0001272: Cerebellar atrophy",
+						"HP:0010571: Elevated levels of phytanic acid",
+						"HP:0008665: Clitoral hypertrophy",
+						"HP:0000474: Thickened nuchal skin fold",
+						"HP:0002126: Polymicrogyria",
+						"HP:0010628: Facial palsy",
+						"HP:0001252: Hypotonia",
+						"HP:0010965: Abnormal circulating phytanic acid concentration",
+						"HP:0002936: Distal sensory impairment",
+						"HP:0000510: Rod-cone dystrophy",
+						"HP:0001392: Abnormality of the liver",
+						"HP:0001290: Generalized hypotonia",
+						"HP:0003693: Distal amyotrophy",
+						"HP:0000174: Abnormal palate morphology",
+						"HP:0002070: Limb ataxia",
+						"HP:0008872: Feeding difficulties in infancy",
+						"HP:0007256: Abnormal pyramidal sign",
+						"HP:0100275: Diffuse cerebellar atrophy",
+						"HP:0002021: Pyloric stenosis",
+						"HP:0001302: Pachygyria",
+						"HP:0001315: Reduced tendon reflexes",
+						"HP:0011675: Arrhythmia",
+						"HP:0006829: Severe muscular hypotonia",
+						"HP:0007772: Impaired smooth pursuit",
+						"HP:0000107: Renal cyst",
+						"HP:0000271: Abnormality of the face",
+						"HP:0001263: Global developmental delay",
+						"HP:0000431: Wide nasal bridge",
+						"HP:0007598: Bilateral single transverse palmar creases",
+						"HP:0001133: Constriction of peripheral visual field",
+						"HP:0000157: Abnormality of the tongue",
+						"HP:0007703: Abnormality of retinal pigmentation",
+						"HP:0001629: Ventricular septal defect",
+						"HP:0000047: Hypospadias",
+						"HP:0003323: Progressive muscle weakness",
+						"HP:0000505: Visual impairment",
+						"HP:0000126: Hydronephrosis",
+						"HP:0000486: Strabismus",
+						"HP:0100022: Abnormality of movement",
+						"HP:0030048: Colpocephaly",
+						"HP:0000662: Nyctalopia",
+						"HP:0002093: Respiratory insufficiency",
+						"HP:0002376: Developmental regression",
+						"HP:0007957: Corneal opacity",
+						"HP:0008207: Primary adrenal insufficiency",
+						"HP:0001928: Abnormality of coagulation",
+						"HP:0001256: Intellectual disability, mild",
+						"HP:0001347: Hyperreflexia"
+					]
+				}
+			]
+		},
+		{
+			"HPO_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://hpo.jax.org/app/browse/search?q=PEX10&navFilter=all"
+				}
+			]
+		},
+		{
+			"HGNC_ID": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "HGNC:8851"
+				}
+			]
+		},
+		{
+			"Model Systems - Mouse - Automated": [
+				{
+					"data_source": "Aliance Genome",
+					"version": "",
+					"value": "Predicted to enable protein C-terminus binding activity. Predicted to be involved in protein import into peroxisome matrix. Predicted to be located in peroxisome. Predicted to be integral component of peroxisomal membrane. Predicted to be active in peroxisomal membrane. Is expressed in dorsal grey horn; medulla oblongata alar plate mantle layer; medulla oblongata basal plate mantle layer; midbrain mantle layer; and pons mantle layer. Human ortholog(s) of this gene implicated in peroxisomal biogenesis disorder and peroxisome biogenesis disorder 6A. Orthologous to human PEX10 (peroxisomal biogenesis factor 10)."
+				}
+			]
+		},
+		{
+			"Gene Summary": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "This gene encodes a protein involved in import of peroxisomal matrix proteins. This protein localizes to the peroxisomal membrane. Mutations in this gene result in phenotypes within the Zellweger spectrum of peroxisomal biogenesis disorders, ranging from neonatal adrenoleukodystrophy to Zellweger syndrome. Alternative splicing results in two transcript variants encoding different isoforms. [provided by RefSeq, Jul 2008]"
+				}
+			]
+		},
+		{
+			"ClinGen_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://search.clinicalgenome.org/kb/genes/HGNC:8851"
+				}
+			]
+		},
+		{
+			"Model Systems - Rat": [
+				{
+					"data_source": "Aliance Genome",
+					"version": "",
+					"value": "Predicted to enable protein C-terminus binding activity. Predicted to be involved in protein import into peroxisome matrix. Located in peroxisomal membrane. Human ortholog(s) of this gene implicated in peroxisomal biogenesis disorder and peroxisome biogenesis disorder 6A. Orthologous to human PEX10 (peroxisomal biogenesis factor 10); INTERACTS WITH 2,3,7,8-tetrachlorodibenzodioxine; bisphenol A; paracetamol."
+				}
+			]
+		},
+		{
+			"Model Systems - Zebrafish - Automated": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "Predicted to enable metal ion binding activity. Predicted to be involved in protein import into peroxisome matrix. Predicted to be located in peroxisome. Predicted to be active in peroxisomal membrane. Human ortholog(s) of this gene implicated in peroxisomal biogenesis disorder and peroxisome biogenesis disorder 6A. Orthologous to human PEX10 (peroxisomal biogenesis factor 10)."
+				}
+			]
+		},
+		{
+			"Rat Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "RGD:1591776"
+				}
+			]
+		},
+		{
+			"Mouse Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "MGI:2684988"
+				}
+			]
+		},
+		{
+			"Zebrafish Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "ZFIN:ZDB-GENE-041010-71"
+				}
+			]
+		},
+		{
+			"Rat_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": []
+				}
+			]
+		},
+		{
+			"Mouse_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": [
+						{
+							"id": "MGI:5639146",
+							"name": "Pex10<sup>m1Nisw</sup>/Pex10<sup>+</sup> [background:] 129S1.B6-Pex10<sup>m1Nisw</sup>",
+							"displayName": "Pex10<m1Nisw>/Pex10<+> [background:] 129S1.B6-Pex10<m1Nisw>",
+							"phenotypes": [
+								"abnormal bile salt homeostasis",
+								"decreased plasmalogen level"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5639146",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "45635987-5daf-4a5b-9cfb-bb5bb93c1429",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "d8c3b1e7-21b3-4f2f-a4cb-e79479aa5c65",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:5639122",
+							"name": "Pex10<sup>m1Nisw</sup>/Pex10<sup>m1Nisw</sup> [background:] 129S1.B6-Pex10<sup>m1Nisw</sup>",
+							"displayName": "Pex10<m1Nisw>/Pex10<m1Nisw> [background:] 129S1.B6-Pex10<m1Nisw>",
+							"phenotypes": [
+								"abnormal axon extension",
+								"abnormal axon fasciculation",
+								"abnormal axon morphology",
+								"abnormal bile salt homeostasis",
+								"abnormal endplate potential",
+								"abnormal motor capabilities/coordination/movement",
+								"abnormal neuromuscular synapse morphology",
+								"ataxia",
+								"cyanosis",
+								"decreased Schwann cell number",
+								"decreased body size",
+								"decreased body weight",
+								"decreased plasmalogen level",
+								"forelimb paralysis",
+								"hindlimb paralysis",
+								"increased fatty acids level",
+								"perinatal lethality, incomplete penetrance",
+								"respiratory distress"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5639122",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "b1dd5299-3fdc-4f45-badc-2485487d1717",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "41dfb736-fc83-4fd0-bac1-10cea2c3c58b",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "c12c8fd3-e4b1-4047-83d5-6f29b26be470",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "2431548c-c112-4e83-a4b8-224390189e11",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "04097a41-be0a-41b6-90ea-34ac2f8685b1",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "1ec1c70c-115f-49e3-9da0-3db6106e6dbe",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "cdcb1f65-bba3-4fef-a362-3f2426ac9586",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "2a05e0ac-fefb-4943-acd7-da262fdf8684",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "a3db1f4b-cf46-4b49-b7ed-21715f8a89ce",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "7b45652e-6f67-4cdd-a2ee-c71852a4c0b6",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "15fc87f0-e3e0-4dd3-bdfb-52cec72deab1",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "4fa6b232-78a9-4367-8346-75eb0d67c169",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "3cdbb8b8-2c4c-4d0f-a3ed-125f6436fa66",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "e6fa7bfd-73bc-448f-a4d4-e8cac97dd892",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "7d343992-086e-468f-b8f0-99cc9e73c55e",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "47ff75c6-0d58-447c-893b-4bb72abd702e",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "8305c755-75eb-4ba3-996e-aa1f04f2b660",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "d912b43f-7a97-452b-82d7-b7bb66eaaeca",
+									"publication": {
+										"id": "PMID:25176044",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						}
+					]
+				}
+			]
+		},
+		{
+			"Zebrafish_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": []
+				}
+			]
+		}
+	]
+},
+{
+	"gene_symbol": "DMD",
+	"gene": "DMD",
+	"annotations": [
+		{
+			"Entrez Gene Id": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": 1756
+				}
+			]
+		},
+		{
+			"Ensembl Gene Id": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "ENSG00000198947"
+				}
+			]
+		},
+		{
+			"HGNC_ID": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "HGNC:2928"
+				}
+			]
+		},
+		{
+			"Gene Summary": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "This gene spans a genomic range of greater than 2 Mb and encodes a large protein containing an N-terminal actin-binding domain and multiple spectrin repeats. The encoded protein forms a component of the dystrophin-glycoprotein complex (DGC), which bridges the inner cytoskeleton and the extracellular matrix. Deletions, duplications, and point mutations at this gene locus may cause Duchenne muscular dystrophy (DMD), Becker muscular dystrophy (BMD), or cardiomyopathy. Alternative promoter usage and alternative splicing result in numerous distinct transcript variants and protein isoforms for this gene. [provided by RefSeq, Dec 2016]"
+				}
+			]
+		},
+		{
+			"ClinGen_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://search.clinicalgenome.org/kb/genes/HGNC:2928"
+				}
+			]
+		},
+		{
+			"NCBI_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=1756"
+				}
+			]
+		},
+		{
+			"gnomAD_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://gnomad.broadinstitute.org/gene/ENSG00000198947?dataset=gnomad_r2_1"
+				}
+			]
+		},
+		{
+			"OMIM": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"X-linked Non-syndromic Intellectual Disability",
+						"Symptomatic Form Of Muscular Dystrophy Of Duchenne And Becker In Female Carriers",
+						"Cardiomyopathy, Dilated, 3b",
+						"Muscular Dystrophy, Becker Type",
+						"Duchenne Muscular Dystrophy",
+						"Familial Isolated Dilated Cardiomyopathy",
+						"Becker Muscular Dystrophy",
+						"Duchenne Muscular Dystrophy"
+					]
+				}
+			]
+		},
+		{
+			"OMIM_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.omim.org/search?index=entry&start=1&sort=score+desc%2C+prefix_sort+desc&search=DMD"
+				}
+			]
+		},
+		{
+			"HPO": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"HP:0002527: Falls",
+						"HP:0002943: Thoracic scoliosis",
+						"HP:0001419: X-linked recessive inheritance",
+						"HP:0003560: Muscular dystrophy",
+						"HP:0003731: Quadriceps muscle weakness",
+						"HP:0001250: Seizure",
+						"HP:0001371: Flexion contracture",
+						"HP:0000455: Broad nasal tip",
+						"HP:0002791: Hypoventilation",
+						"HP:0002910: Elevated hepatic transaminase",
+						"HP:0011800: Midface retrusion",
+						"HP:0003115: Abnormal EKG",
+						"HP:0003198: Myopathy",
+						"HP:0000020: Urinary incontinence",
+						"HP:0008587: Mild neurosensory hearing impairment",
+						"HP:0000256: Macrocephaly",
+						"HP:0000729: Autistic behavior",
+						"HP:0002515: Waddling gait",
+						"HP:0002913: Myoglobinuria",
+						"HP:0000637: Long palpebral fissure",
+						"HP:0002878: Respiratory failure",
+						"HP:0000629: Periorbital fullness",
+						"HP:0003236: Elevated circulating creatine kinase concentration",
+						"HP:0012086: Abnormal urinary color",
+						"HP:0003487: Babinski sign",
+						"HP:0002465: Poor speech",
+						"HP:0003710: Exercise-induced muscle cramps",
+						"HP:0000494: Downslanted palpebral fissures",
+						"HP:0001435: Abnormality of the shoulder girdle musculature",
+						"HP:0003391: Gowers sign",
+						"HP:0002187: Intellectual disability, profound",
+						"HP:0000684: Delayed eruption of teeth",
+						"HP:0002307: Drooling",
+						"HP:0002650: Scoliosis",
+						"HP:0010628: Facial palsy",
+						"HP:0001712: Left ventricular hypertrophy",
+						"HP:0001252: Hypotonia",
+						"HP:0001513: Obesity",
+						"HP:0002814: Abnormality of the lower limb",
+						"HP:0001328: Specific learning disability",
+						"HP:0005824: Clinodactyly of the 2nd toe",
+						"HP:0012704: Widened subarachnoid space",
+						"HP:0000407: Sensorineural hearing impairment",
+						"HP:0100543: Cognitive impairment",
+						"HP:0010864: Intellectual disability, severe",
+						"HP:0001763: Pes planus",
+						"HP:0001874: Abnormality of neutrophils",
+						"HP:0000219: Thin upper lip vermilion",
+						"HP:0003546: Exercise intolerance",
+						"HP:0008981: Calf muscle hypertrophy",
+						"HP:0001270: Motor delay",
+						"HP:0001290: Generalized hypotonia",
+						"HP:0003701: Proximal muscle weakness",
+						"HP:0100578: Lipoatrophy",
+						"HP:0000179: Thick lower lip vermilion",
+						"HP:0012378: Fatigue",
+						"HP:0002540: Inability to walk",
+						"HP:0002245: Meckel diverticulum",
+						"HP:0002942: Thoracic kyphosis",
+						"HP:0001644: Dilated cardiomyopathy",
+						"HP:0002021: Pyloric stenosis",
+						"HP:0003457: EMG abnormality",
+						"HP:0002987: Elbow flexion contracture",
+						"HP:0003707: Calf muscle pseudohypertrophy",
+						"HP:0011675: Arrhythmia",
+						"HP:0000750: Delayed speech and language development",
+						"HP:0002355: Difficulty walking",
+						"HP:0001263: Global developmental delay",
+						"HP:0030051: Tip-toe gait",
+						"HP:0003324: Generalized muscle weakness",
+						"HP:0002121: Generalized non-motor (absence) seizure",
+						"HP:0003394: Muscle spasm",
+						"HP:0005280: Depressed nasal bridge",
+						"HP:0001635: Congestive heart failure",
+						"HP:0001265: Hyporeflexia",
+						"HP:0001638: Cardiomyopathy",
+						"HP:0007018: Attention deficit hyperactivity disorder",
+						"HP:0001324: Muscle weakness",
+						"HP:0001417: X-linked inheritance",
+						"HP:0001518: Small for gestational age",
+						"HP:0002342: Intellectual disability, moderate",
+						"HP:0000982: Palmoplantar keratoderma",
+						"HP:0004691: 2-3 toe syndactyly",
+						"HP:0003307: Hyperlordosis",
+						"HP:0003323: Progressive muscle weakness",
+						"HP:0002069: Bilateral tonic-clonic seizure",
+						"HP:0030097: Absent muscle dystrophin expression",
+						"HP:0008504: Moderate sensorineural hearing impairment",
+						"HP:0003326: Myalgia",
+						"HP:0003551: Difficulty climbing stairs",
+						"HP:0002093: Respiratory insufficiency",
+						"HP:0000343: Long philtrum",
+						"HP:0003202: Skeletal muscle atrophy",
+						"HP:0006118: Shortening of all distal phalanges of the fingers",
+						"HP:0001256: Intellectual disability, mild",
+						"HP:0002938: Lumbar hyperlordosis"
+					]
+				}
+			]
+		},
+		{
+			"HPO_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://hpo.jax.org/app/browse/search?q=DMD&navFilter=all"
+				}
+			]
+		},
+		{
+			"Model Systems - Mouse - Automated": [
+				{
+					"data_source": "Aliance Genome",
+					"version": "",
+					"value": "Enables nitric-oxide synthase binding activity. Involved in several processes, including negative regulation of protein modification process; positive regulation of cell-matrix adhesion; and regulation of cation transmembrane transport. Acts upstream of or within several processes, including muscle cell cellular homeostasis; negative regulation of ERK1 and ERK2 cascade; and nervous system development. Located in several cellular components, including Z disc; cell-substrate junction; and sarcolemma. Part of dystrophin-associated glycoprotein complex. Is expressed in several structures, including alimentary system; cardiovascular system; central nervous system; musculature; and skin. Used to study Becker muscular dystrophy and Duchenne muscular dystrophy. Human ortholog(s) of this gene implicated in cognitive disorder; dilated cardiomyopathy (multiple); intellectual disability; and muscular dystrophy (multiple). Orthologous to human DMD (dystrophin)."
+				}
+			]
+		},
+		{
+			"Model Systems - Zebrafish - Automated": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "Predicted to enable actin filament binding activity. Acts upstream of or within several processes, including sarcomere organization; skeletal muscle organ development; and somatic muscle development. Located in sarcolemma. Is expressed in several structures, including axial mesoderm; axis; chordo neural hinge; musculature system; and somite. Used to study Duchenne muscular dystrophy and muscular dystrophy. Human ortholog(s) of this gene implicated in cognitive disorder; dilated cardiomyopathy (multiple); intellectual disability; and muscular dystrophy (multiple). Orthologous to human DMD (dystrophin)."
+				}
+			]
+		},
+		{
+			"Model Systems - Rat": [
+				{
+					"data_source": "Aliance Genome",
+					"version": "",
+					"value": "Enables several functions, including PDZ domain binding activity; integrin binding activity; and lamin binding activity. Involved in several processes, including nervous system development; regulation of neuron differentiation; and response to denervation involved in regulation of muscle adaptation. Located in several cellular components, including mitochondrial membrane; neurofilament; and secretory vesicle. Part of dystrophin-associated glycoprotein complex. Used to study Duchenne muscular dystrophy; brain edema; and dilated cardiomyopathy. Biomarker of muscular atrophy; retinal degeneration; and status epilepticus. Human ortholog(s) of this gene implicated in cognitive disorder; dilated cardiomyopathy (multiple); intellectual disability; and muscular dystrophy (multiple). Orthologous to human DMD (dystrophin); INTERACTS WITH (+)-pilocarpine; 2,3,7,8-tetrachlorodibenzodioxine; 2,3,7,8-Tetrachlorodibenzofuran."
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_002972.2:c.5474_5475delTG",
+	"transcripts": [
+		{
+			"transcript_id": "NM_001242898.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001242898.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001242899.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001242899.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001242900.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001242900.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351641.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351641.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351642.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351642.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351643.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351643.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351644.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351644.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351645.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351645.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351646.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351646.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351647.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351647.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001351648.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001351648.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001365819.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001365819.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001365836.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001365836.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_002972.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_002972.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_014678.5",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_014678.5"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"downstream_gene_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
 						}
 					]
 				}
@@ -1381,1292 +5253,6 @@
 					"data_source": "Alliance Genome",
 					"version": "",
 					"value": []
-				}
-			]
-		}
-	]
-},
-{
-	"hgvs_variant": "NM_005249.5:c.924G>A",
-	"transcripts": [
-		{
-			"transcript_id": "NM_005249.5",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_005249.5"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"stop_gained"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				},
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_005249.5"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NR_026731.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_026731.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"upstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				},
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_026731.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NR_026732.1",
-			"annotations": [
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"upstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				},
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_026732.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NR_125758.1",
-			"annotations": [
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"upstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				},
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_125758.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				}
-			]
-		}
-	],
-	"annotations": [
-		{
-			"ClinVar_Variantion_Id": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "13871"
-				}
-			]
-		},
-		{
-			"CADD": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": 37
-				}
-			]
-		},
-		{
-			"ClinVar_variant_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/13871"
-				}
-			]
-		}
-	]
-},
-{
-	"hgvs_variant": "NM_170707.3:c.745C>T",
-	"transcripts": [
-		{
-			"transcript_id": "NM_001257374.3",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001257374.3"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0.999
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001282624.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001282624.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 1
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001282625.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001282625.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 1
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001282626.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001282626.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 1
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_005572.4",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_005572.4"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 1
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_170707.4",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_170707.4"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 1
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_170708.4",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_170708.4"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0.999
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		}
-	],
-	"annotations": [
-		{
-			"ClinVar_Variantion_Id": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "14524"
-				}
-			]
-		},
-		{
-			"ClinVar_Variantion_Id": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "14524"
-				}
-			]
-		},
-		{
-			"CADD": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": 26.5
-				}
-			]
-		},
-		{
-			"ClinVar_variant_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/14524"
-				}
-			]
-		}
-	]
-},
-{
-	"hgvs_variant": "NM_005249.5:c.256dup",
-	"transcripts": [
-		{
-			"transcript_id": "NM_005249.5",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_005249.5"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"frameshift_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NR_125758.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_125758.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"upstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		}
-	],
-	"annotations": [
-		{
-			"CADD": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": 25.2
-				}
-			]
-		}
-	]
-},
-{
-	"gene_symbol": "DMD",
-	"gene": "DMD",
-	"annotations": [
-		{
-			"Entrez Gene Id": [
-				{
-					"data_source": "HPO",
-					"version": "",
-					"value": 1756
-				}
-			]
-		},
-		{
-			"Ensembl Gene Id": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": "ENSG00000198947"
-				}
-			]
-		},
-		{
-			"HGNC_ID": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": "HGNC:2928"
-				}
-			]
-		},
-		{
-			"Gene Summary": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "This gene spans a genomic range of greater than 2 Mb and encodes a large protein containing an N-terminal actin-binding domain and multiple spectrin repeats. The encoded protein forms a component of the dystrophin-glycoprotein complex (DGC), which bridges the inner cytoskeleton and the extracellular matrix. Deletions, duplications, and point mutations at this gene locus may cause Duchenne muscular dystrophy (DMD), Becker muscular dystrophy (BMD), or cardiomyopathy. Alternative promoter usage and alternative splicing result in numerous distinct transcript variants and protein isoforms for this gene. [provided by RefSeq, Dec 2016]"
-				}
-			]
-		},
-		{
-			"ClinGen_gene_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://search.clinicalgenome.org/kb/genes/HGNC:2928"
-				}
-			]
-		},
-		{
-			"NCBI_gene_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=1756"
-				}
-			]
-		},
-		{
-			"gnomAD_gene_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://gnomad.broadinstitute.org/gene/ENSG00000198947?dataset=gnomad_r2_1"
-				}
-			]
-		},
-		{
-			"OMIM": [
-				{
-					"data_source": "HPO",
-					"version": "",
-					"value": [
-						"X-linked Non-syndromic Intellectual Disability",
-						"Symptomatic Form Of Muscular Dystrophy Of Duchenne And Becker In Female Carriers",
-						"Cardiomyopathy, Dilated, 3b",
-						"Muscular Dystrophy, Becker Type",
-						"Duchenne Muscular Dystrophy",
-						"Familial Isolated Dilated Cardiomyopathy",
-						"Becker Muscular Dystrophy",
-						"Duchenne Muscular Dystrophy"
-					]
-				}
-			]
-		},
-		{
-			"OMIM_gene_search_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.omim.org/search?index=entry&start=1&sort=score+desc%2C+prefix_sort+desc&search=DMD"
-				}
-			]
-		},
-		{
-			"HPO": [
-				{
-					"data_source": "HPO",
-					"version": "",
-					"value": [
-						"HP:0002527: Falls",
-						"HP:0002943: Thoracic scoliosis",
-						"HP:0001419: X-linked recessive inheritance",
-						"HP:0003560: Muscular dystrophy",
-						"HP:0003731: Quadriceps muscle weakness",
-						"HP:0001250: Seizure",
-						"HP:0001371: Flexion contracture",
-						"HP:0000455: Broad nasal tip",
-						"HP:0002791: Hypoventilation",
-						"HP:0002910: Elevated hepatic transaminase",
-						"HP:0011800: Midface retrusion",
-						"HP:0003115: Abnormal EKG",
-						"HP:0003198: Myopathy",
-						"HP:0000020: Urinary incontinence",
-						"HP:0008587: Mild neurosensory hearing impairment",
-						"HP:0000256: Macrocephaly",
-						"HP:0000729: Autistic behavior",
-						"HP:0002515: Waddling gait",
-						"HP:0002913: Myoglobinuria",
-						"HP:0000637: Long palpebral fissure",
-						"HP:0002878: Respiratory failure",
-						"HP:0000629: Periorbital fullness",
-						"HP:0003236: Elevated circulating creatine kinase concentration",
-						"HP:0012086: Abnormal urinary color",
-						"HP:0003487: Babinski sign",
-						"HP:0002465: Poor speech",
-						"HP:0003710: Exercise-induced muscle cramps",
-						"HP:0000494: Downslanted palpebral fissures",
-						"HP:0001435: Abnormality of the shoulder girdle musculature",
-						"HP:0003391: Gowers sign",
-						"HP:0002187: Intellectual disability, profound",
-						"HP:0000684: Delayed eruption of teeth",
-						"HP:0002307: Drooling",
-						"HP:0002650: Scoliosis",
-						"HP:0010628: Facial palsy",
-						"HP:0001712: Left ventricular hypertrophy",
-						"HP:0001252: Hypotonia",
-						"HP:0001513: Obesity",
-						"HP:0002814: Abnormality of the lower limb",
-						"HP:0001328: Specific learning disability",
-						"HP:0005824: Clinodactyly of the 2nd toe",
-						"HP:0012704: Widened subarachnoid space",
-						"HP:0000407: Sensorineural hearing impairment",
-						"HP:0100543: Cognitive impairment",
-						"HP:0010864: Intellectual disability, severe",
-						"HP:0001763: Pes planus",
-						"HP:0001874: Abnormality of neutrophils",
-						"HP:0000219: Thin upper lip vermilion",
-						"HP:0003546: Exercise intolerance",
-						"HP:0008981: Calf muscle hypertrophy",
-						"HP:0001270: Motor delay",
-						"HP:0001290: Generalized hypotonia",
-						"HP:0003701: Proximal muscle weakness",
-						"HP:0100578: Lipoatrophy",
-						"HP:0000179: Thick lower lip vermilion",
-						"HP:0012378: Fatigue",
-						"HP:0002540: Inability to walk",
-						"HP:0002245: Meckel diverticulum",
-						"HP:0002942: Thoracic kyphosis",
-						"HP:0001644: Dilated cardiomyopathy",
-						"HP:0002021: Pyloric stenosis",
-						"HP:0003457: EMG abnormality",
-						"HP:0002987: Elbow flexion contracture",
-						"HP:0003707: Calf muscle pseudohypertrophy",
-						"HP:0011675: Arrhythmia",
-						"HP:0000750: Delayed speech and language development",
-						"HP:0002355: Difficulty walking",
-						"HP:0001263: Global developmental delay",
-						"HP:0030051: Tip-toe gait",
-						"HP:0003324: Generalized muscle weakness",
-						"HP:0002121: Generalized non-motor (absence) seizure",
-						"HP:0003394: Muscle spasm",
-						"HP:0005280: Depressed nasal bridge",
-						"HP:0001635: Congestive heart failure",
-						"HP:0001265: Hyporeflexia",
-						"HP:0001638: Cardiomyopathy",
-						"HP:0007018: Attention deficit hyperactivity disorder",
-						"HP:0001324: Muscle weakness",
-						"HP:0001417: X-linked inheritance",
-						"HP:0001518: Small for gestational age",
-						"HP:0002342: Intellectual disability, moderate",
-						"HP:0000982: Palmoplantar keratoderma",
-						"HP:0004691: 2-3 toe syndactyly",
-						"HP:0003307: Hyperlordosis",
-						"HP:0003323: Progressive muscle weakness",
-						"HP:0002069: Bilateral tonic-clonic seizure",
-						"HP:0030097: Absent muscle dystrophin expression",
-						"HP:0008504: Moderate sensorineural hearing impairment",
-						"HP:0003326: Myalgia",
-						"HP:0003551: Difficulty climbing stairs",
-						"HP:0002093: Respiratory insufficiency",
-						"HP:0000343: Long philtrum",
-						"HP:0003202: Skeletal muscle atrophy",
-						"HP:0006118: Shortening of all distal phalanges of the fingers",
-						"HP:0001256: Intellectual disability, mild",
-						"HP:0002938: Lumbar hyperlordosis"
-					]
-				}
-			]
-		},
-		{
-			"HPO_gene_search_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://hpo.jax.org/app/browse/search?q=DMD&navFilter=all"
-				}
-			]
-		},
-		{
-			"Model Systems - Mouse - Automated": [
-				{
-					"data_source": "Aliance Genome",
-					"version": "",
-					"value": "Enables nitric-oxide synthase binding activity. Involved in several processes, including negative regulation of protein modification process; positive regulation of cell-matrix adhesion; and regulation of cation transmembrane transport. Acts upstream of or within several processes, including muscle cell cellular homeostasis; negative regulation of ERK1 and ERK2 cascade; and nervous system development. Located in several cellular components, including Z disc; cell-substrate junction; and sarcolemma. Part of dystrophin-associated glycoprotein complex. Is expressed in several structures, including alimentary system; cardiovascular system; central nervous system; musculature; and skin. Used to study Becker muscular dystrophy and Duchenne muscular dystrophy. Human ortholog(s) of this gene implicated in cognitive disorder; dilated cardiomyopathy (multiple); intellectual disability; and muscular dystrophy (multiple). Orthologous to human DMD (dystrophin)."
-				}
-			]
-		},
-		{
-			"Model Systems - Zebrafish - Automated": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "Predicted to enable actin filament binding activity. Acts upstream of or within several processes, including sarcomere organization; skeletal muscle organ development; and somatic muscle development. Located in sarcolemma. Is expressed in several structures, including axial mesoderm; axis; chordo neural hinge; musculature system; and somite. Used to study Duchenne muscular dystrophy and muscular dystrophy. Human ortholog(s) of this gene implicated in cognitive disorder; dilated cardiomyopathy (multiple); intellectual disability; and muscular dystrophy (multiple). Orthologous to human DMD (dystrophin)."
-				}
-			]
-		},
-		{
-			"Model Systems - Rat": [
-				{
-					"data_source": "Aliance Genome",
-					"version": "",
-					"value": "Enables several functions, including PDZ domain binding activity; integrin binding activity; and lamin binding activity. Involved in several processes, including nervous system development; regulation of neuron differentiation; and response to denervation involved in regulation of muscle adaptation. Located in several cellular components, including mitochondrial membrane; neurofilament; and secretory vesicle. Part of dystrophin-associated glycoprotein complex. Used to study Duchenne muscular dystrophy; brain edema; and dilated cardiomyopathy. Biomarker of muscular atrophy; retinal degeneration; and status epilepticus. Human ortholog(s) of this gene implicated in cognitive disorder; dilated cardiomyopathy (multiple); intellectual disability; and muscular dystrophy (multiple). Orthologous to human DMD (dystrophin); INTERACTS WITH (+)-pilocarpine; 2,3,7,8-tetrachlorodibenzodioxine; 2,3,7,8-Tetrachlorodibenzofuran."
 				}
 			]
 		}
@@ -8367,2592 +10953,6 @@
 							}
 						}
 					]
-				}
-			]
-		}
-	]
-},
-{
-	"gene_symbol": "PEX10",
-	"gene": "PEX10",
-	"annotations": [
-		{
-			"Entrez Gene Id": [
-				{
-					"data_source": "HPO",
-					"version": "",
-					"value": 5192
-				}
-			]
-		},
-		{
-			"Ensembl Gene Id": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": "ENSG00000157911"
-				}
-			]
-		},
-		{
-			"NCBI_gene_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=5192"
-				}
-			]
-		},
-		{
-			"gnomAD_gene_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://gnomad.broadinstitute.org/gene/ENSG00000157911?dataset=gnomad_r2_1"
-				}
-			]
-		},
-		{
-			"OMIM_gene_search_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.omim.org/search?index=entry&start=1&sort=score+desc%2C+prefix_sort+desc&search=PEX10"
-				}
-			]
-		},
-		{
-			"OMIM": [
-				{
-					"data_source": "HPO",
-					"version": "",
-					"value": [
-						"Infantile Refsum Disease",
-						"Peroxisome Biogenesis Disorder 6a (zellweger)",
-						"Peroxisome Biogenesis Disorder 6b",
-						"Autosomal Recessive Ataxia Due To Pex10 Deficiency",
-						"Neonatal Adrenoleukodystrophy",
-						"Zellweger Syndrome"
-					]
-				}
-			]
-		},
-		{
-			"HPO": [
-				{
-					"data_source": "HPO",
-					"version": "",
-					"value": [
-						"HP:0000952: Jaundice",
-						"HP:0000268: Dolichocephaly",
-						"HP:0000368: Low-set, posteriorly rotated ears",
-						"HP:0000028: Cryptorchidism",
-						"HP:0000256: Macrocephaly",
-						"HP:0000508: Ptosis",
-						"HP:0002078: Truncal ataxia",
-						"HP:0000252: Microcephaly",
-						"HP:0000286: Epicanthus",
-						"HP:0001508: Failure to thrive",
-						"HP:0009891: Underdeveloped supraorbital ridges",
-						"HP:0008167: Very long chain fatty acid accumulation",
-						"HP:0000218: High palate",
-						"HP:0001319: Neonatal hypotonia",
-						"HP:0002457: Abnormal head movements",
-						"HP:0011499: Mydriasis",
-						"HP:0000627: Posterior embryotoxon",
-						"HP:0001410: Decreased liver function",
-						"HP:0001939: Abnormality of metabolism/homeostasis",
-						"HP:0001761: Pes cavus",
-						"HP:0002652: Skeletal dysplasia",
-						"HP:0002353: EEG abnormality",
-						"HP:0000641: Dysmetric saccades",
-						"HP:0002024: Malabsorption",
-						"HP:0000407: Sensorineural hearing impairment",
-						"HP:0100543: Cognitive impairment",
-						"HP:0005469: Flat occiput",
-						"HP:0002269: Abnormality of neuronal migration",
-						"HP:0000369: Low-set ears",
-						"HP:0001260: Dysarthria",
-						"HP:0005978: Type II diabetes mellitus",
-						"HP:0007240: Progressive gait ataxia",
-						"HP:0007002: Motor axonal neuropathy",
-						"HP:0011344: Severe global developmental delay",
-						"HP:0002500: Abnormal cerebral white matter morphology",
-						"HP:0001257: Spasticity",
-						"HP:0005280: Depressed nasal bridge",
-						"HP:0002240: Hepatomegaly",
-						"HP:0000532: Abnormal chorioretinal morphology",
-						"HP:0000648: Optic atrophy",
-						"HP:0001265: Hyporeflexia",
-						"HP:0002080: Intention tremor",
-						"HP:0001638: Cardiomyopathy",
-						"HP:0012368: Flat face",
-						"HP:0008572: External ear malformation",
-						"HP:0001399: Hepatic failure",
-						"HP:0012736: Profound global developmental delay",
-						"HP:0000582: Upslanted palpebral fissure",
-						"HP:0000708: Behavioral abnormality",
-						"HP:0002073: Progressive cerebellar ataxia",
-						"HP:0000501: Glaucoma",
-						"HP:0001250: Seizure",
-						"HP:0001622: Premature birth",
-						"HP:0010655: Epiphyseal stippling",
-						"HP:0000556: Retinal dystrophy",
-						"HP:0000347: Micrognathia",
-						"HP:0000365: Hearing impairment",
-						"HP:0000007: Autosomal recessive inheritance",
-						"HP:0008935: Generalized neonatal hypotonia",
-						"HP:0000348: High forehead",
-						"HP:0001088: Brushfield spots",
-						"HP:0000003: Multicystic kidney dysplasia",
-						"HP:0008064: Ichthyosis",
-						"HP:0004322: Short stature",
-						"HP:0000260: Wide anterior fontanel",
-						"HP:0005930: Abnormality of epiphysis morphology",
-						"HP:0000463: Anteverted nares",
-						"HP:0001251: Ataxia",
-						"HP:0000639: Nystagmus",
-						"HP:0000518: Cataract",
-						"HP:0001272: Cerebellar atrophy",
-						"HP:0010571: Elevated levels of phytanic acid",
-						"HP:0008665: Clitoral hypertrophy",
-						"HP:0000474: Thickened nuchal skin fold",
-						"HP:0002126: Polymicrogyria",
-						"HP:0010628: Facial palsy",
-						"HP:0001252: Hypotonia",
-						"HP:0010965: Abnormal circulating phytanic acid concentration",
-						"HP:0002936: Distal sensory impairment",
-						"HP:0000510: Rod-cone dystrophy",
-						"HP:0001392: Abnormality of the liver",
-						"HP:0001290: Generalized hypotonia",
-						"HP:0003693: Distal amyotrophy",
-						"HP:0000174: Abnormal palate morphology",
-						"HP:0002070: Limb ataxia",
-						"HP:0008872: Feeding difficulties in infancy",
-						"HP:0007256: Abnormal pyramidal sign",
-						"HP:0100275: Diffuse cerebellar atrophy",
-						"HP:0002021: Pyloric stenosis",
-						"HP:0001302: Pachygyria",
-						"HP:0001315: Reduced tendon reflexes",
-						"HP:0011675: Arrhythmia",
-						"HP:0006829: Severe muscular hypotonia",
-						"HP:0007772: Impaired smooth pursuit",
-						"HP:0000107: Renal cyst",
-						"HP:0000271: Abnormality of the face",
-						"HP:0001263: Global developmental delay",
-						"HP:0000431: Wide nasal bridge",
-						"HP:0007598: Bilateral single transverse palmar creases",
-						"HP:0001133: Constriction of peripheral visual field",
-						"HP:0000157: Abnormality of the tongue",
-						"HP:0007703: Abnormality of retinal pigmentation",
-						"HP:0001629: Ventricular septal defect",
-						"HP:0000047: Hypospadias",
-						"HP:0003323: Progressive muscle weakness",
-						"HP:0000505: Visual impairment",
-						"HP:0000126: Hydronephrosis",
-						"HP:0000486: Strabismus",
-						"HP:0100022: Abnormality of movement",
-						"HP:0030048: Colpocephaly",
-						"HP:0000662: Nyctalopia",
-						"HP:0002093: Respiratory insufficiency",
-						"HP:0002376: Developmental regression",
-						"HP:0007957: Corneal opacity",
-						"HP:0008207: Primary adrenal insufficiency",
-						"HP:0001928: Abnormality of coagulation",
-						"HP:0001256: Intellectual disability, mild",
-						"HP:0001347: Hyperreflexia"
-					]
-				}
-			]
-		},
-		{
-			"HPO_gene_search_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://hpo.jax.org/app/browse/search?q=PEX10&navFilter=all"
-				}
-			]
-		},
-		{
-			"HGNC_ID": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": "HGNC:8851"
-				}
-			]
-		},
-		{
-			"Model Systems - Mouse - Automated": [
-				{
-					"data_source": "Aliance Genome",
-					"version": "",
-					"value": "Predicted to enable protein C-terminus binding activity. Predicted to be involved in protein import into peroxisome matrix. Predicted to be located in peroxisome. Predicted to be integral component of peroxisomal membrane. Predicted to be active in peroxisomal membrane. Is expressed in dorsal grey horn; medulla oblongata alar plate mantle layer; medulla oblongata basal plate mantle layer; midbrain mantle layer; and pons mantle layer. Human ortholog(s) of this gene implicated in peroxisomal biogenesis disorder and peroxisome biogenesis disorder 6A. Orthologous to human PEX10 (peroxisomal biogenesis factor 10)."
-				}
-			]
-		},
-		{
-			"Gene Summary": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "This gene encodes a protein involved in import of peroxisomal matrix proteins. This protein localizes to the peroxisomal membrane. Mutations in this gene result in phenotypes within the Zellweger spectrum of peroxisomal biogenesis disorders, ranging from neonatal adrenoleukodystrophy to Zellweger syndrome. Alternative splicing results in two transcript variants encoding different isoforms. [provided by RefSeq, Jul 2008]"
-				}
-			]
-		},
-		{
-			"ClinGen_gene_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://search.clinicalgenome.org/kb/genes/HGNC:8851"
-				}
-			]
-		},
-		{
-			"Model Systems - Rat": [
-				{
-					"data_source": "Aliance Genome",
-					"version": "",
-					"value": "Predicted to enable protein C-terminus binding activity. Predicted to be involved in protein import into peroxisome matrix. Located in peroxisomal membrane. Human ortholog(s) of this gene implicated in peroxisomal biogenesis disorder and peroxisome biogenesis disorder 6A. Orthologous to human PEX10 (peroxisomal biogenesis factor 10); INTERACTS WITH 2,3,7,8-tetrachlorodibenzodioxine; bisphenol A; paracetamol."
-				}
-			]
-		},
-		{
-			"Model Systems - Zebrafish - Automated": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "Predicted to enable metal ion binding activity. Predicted to be involved in protein import into peroxisome matrix. Predicted to be located in peroxisome. Predicted to be active in peroxisomal membrane. Human ortholog(s) of this gene implicated in peroxisomal biogenesis disorder and peroxisome biogenesis disorder 6A. Orthologous to human PEX10 (peroxisomal biogenesis factor 10)."
-				}
-			]
-		},
-		{
-			"Rat Gene Identifier": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "RGD:1591776"
-				}
-			]
-		},
-		{
-			"Mouse Gene Identifier": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "MGI:2684988"
-				}
-			]
-		},
-		{
-			"Zebrafish Gene Identifier": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": "ZFIN:ZDB-GENE-041010-71"
-				}
-			]
-		},
-		{
-			"Rat_Alliance_Genome_Models": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": []
-				}
-			]
-		},
-		{
-			"Mouse_Alliance_Genome_Models": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": [
-						{
-							"id": "MGI:5639146",
-							"name": "Pex10<sup>m1Nisw</sup>/Pex10<sup>+</sup> [background:] 129S1.B6-Pex10<sup>m1Nisw</sup>",
-							"displayName": "Pex10<m1Nisw>/Pex10<+> [background:] 129S1.B6-Pex10<m1Nisw>",
-							"phenotypes": [
-								"abnormal bile salt homeostasis",
-								"decreased plasmalogen level"
-							],
-							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5639146",
-							"type": "genotype",
-							"crossReference": null,
-							"source": {
-								"name": "MGI",
-								"url": null
-							},
-							"diseaseAssociationType": null,
-							"diseaseModels": [],
-							"publicationEvidenceCodes": [
-								{
-									"primaryKey": "45635987-5daf-4a5b-9cfb-bb5bb93c1429",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "d8c3b1e7-21b3-4f2f-a4cb-e79479aa5c65",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								}
-							],
-							"conditions": {},
-							"conditionModifiers": {},
-							"alleles": [],
-							"sequenceTargetingReagents": [],
-							"species": null
-						},
-						{
-							"id": "MGI:5639122",
-							"name": "Pex10<sup>m1Nisw</sup>/Pex10<sup>m1Nisw</sup> [background:] 129S1.B6-Pex10<sup>m1Nisw</sup>",
-							"displayName": "Pex10<m1Nisw>/Pex10<m1Nisw> [background:] 129S1.B6-Pex10<m1Nisw>",
-							"phenotypes": [
-								"abnormal axon extension",
-								"abnormal axon fasciculation",
-								"abnormal axon morphology",
-								"abnormal bile salt homeostasis",
-								"abnormal endplate potential",
-								"abnormal motor capabilities/coordination/movement",
-								"abnormal neuromuscular synapse morphology",
-								"ataxia",
-								"cyanosis",
-								"decreased Schwann cell number",
-								"decreased body size",
-								"decreased body weight",
-								"decreased plasmalogen level",
-								"forelimb paralysis",
-								"hindlimb paralysis",
-								"increased fatty acids level",
-								"perinatal lethality, incomplete penetrance",
-								"respiratory distress"
-							],
-							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5639122",
-							"type": "genotype",
-							"crossReference": null,
-							"source": {
-								"name": "MGI",
-								"url": null
-							},
-							"diseaseAssociationType": null,
-							"diseaseModels": [],
-							"publicationEvidenceCodes": [
-								{
-									"primaryKey": "b1dd5299-3fdc-4f45-badc-2485487d1717",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "41dfb736-fc83-4fd0-bac1-10cea2c3c58b",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "c12c8fd3-e4b1-4047-83d5-6f29b26be470",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "2431548c-c112-4e83-a4b8-224390189e11",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "04097a41-be0a-41b6-90ea-34ac2f8685b1",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "1ec1c70c-115f-49e3-9da0-3db6106e6dbe",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "cdcb1f65-bba3-4fef-a362-3f2426ac9586",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "2a05e0ac-fefb-4943-acd7-da262fdf8684",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "a3db1f4b-cf46-4b49-b7ed-21715f8a89ce",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "7b45652e-6f67-4cdd-a2ee-c71852a4c0b6",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "15fc87f0-e3e0-4dd3-bdfb-52cec72deab1",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "4fa6b232-78a9-4367-8346-75eb0d67c169",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "3cdbb8b8-2c4c-4d0f-a3ed-125f6436fa66",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "e6fa7bfd-73bc-448f-a4d4-e8cac97dd892",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "7d343992-086e-468f-b8f0-99cc9e73c55e",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "47ff75c6-0d58-447c-893b-4bb72abd702e",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "8305c755-75eb-4ba3-996e-aa1f04f2b660",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								},
-								{
-									"primaryKey": "d912b43f-7a97-452b-82d7-b7bb66eaaeca",
-									"publication": {
-										"id": "PMID:25176044",
-										"url": "https://www.ncbi.nlm.nih.gov/pubmed/25176044"
-									},
-									"dateAssigned": null,
-									"evidenceCodes": []
-								}
-							],
-							"conditions": {},
-							"conditionModifiers": {},
-							"alleles": [],
-							"sequenceTargetingReagents": [],
-							"species": null
-						}
-					]
-				}
-			]
-		},
-		{
-			"Zebrafish_Alliance_Genome_Models": [
-				{
-					"data_source": "Alliance Genome",
-					"version": "",
-					"value": []
-				}
-			]
-		}
-	]
-},
-{
-	"hgvs_variant": "NM_153818.2:c.928C>G",
-	"transcripts": [
-		{
-			"transcript_id": "NM_001374425.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001374425.1"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001374426.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001374426.1"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001374427.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001374427.1"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_002617.4",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_002617.4"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0.999
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_007033.5",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_007033.5"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_153818.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_153818.2"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0.999
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "probably_damaging"
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"missense_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "deleterious"
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": 0
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODERATE"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NR_164636.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_164636.1"
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"non_coding_transcript_exon_variant"
-							]
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		}
-	],
-	"annotations": [
-		{
-			"ClinVar_Variantion_Id": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "552930"
-				}
-			]
-		},
-		{
-			"CADD": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": 27.4
-				}
-			]
-		},
-		{
-			"ClinVar_variant_url": [
-				{
-					"data_source": "Rosalution",
-					"version": "",
-					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/552930"
-				}
-			]
-		}
-	]
-},
-{
-	"hgvs_variant": "NM_153818.2:c.28dup",
-	"transcripts": [
-		{
-			"transcript_id": "NM_001374425.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001374425.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"frameshift_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001374426.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001374426.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"intron_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001374427.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001374427.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"intron_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_002617.4",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_002617.4"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"frameshift_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_153818.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_153818.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"frameshift_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NR_164636.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NR_164636.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"intron_variant",
-								"non_coding_transcript_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		}
-	],
-	"annotations": [
-		{
-			"CADD": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": null
-				}
-			]
-		}
-	]
-},
-{
-	"hgvs_variant": "NM_002972.2:c.5474_5475delTG",
-	"transcripts": [
-		{
-			"transcript_id": "NM_001242898.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001242898.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001242899.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001242899.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001242900.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001242900.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351641.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351641.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351642.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351642.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351643.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351643.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351644.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351644.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351645.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351645.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351646.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351646.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351647.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351647.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001351648.2",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001351648.2"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001365819.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001365819.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"frameshift_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_001365836.1",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_001365836.1"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_002972.4",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_002972.4"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"frameshift_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "HIGH"
-						}
-					]
-				}
-			]
-		},
-		{
-			"transcript_id": "NM_014678.5",
-			"annotations": [
-				{
-					"transcript_id": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "NM_014678.5"
-						}
-					]
-				},
-				{
-					"Polyphen Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Polyphen Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Prediction": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"SIFT Score": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": null
-						}
-					]
-				},
-				{
-					"Consequences": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": [
-								"downstream_gene_variant"
-							]
-						}
-					]
-				},
-				{
-					"Impact": [
-						{
-							"data_source": "Ensembl",
-							"version": "",
-							"value": "MODIFIER"
-						}
-					]
-				}
-			]
-		}
-	],
-	"annotations": [
-		{
-			"CADD": [
-				{
-					"data_source": "Ensembl",
-					"version": "",
-					"value": null
 				}
 			]
 		}
@@ -19885,6 +19885,2984 @@
 							"species": null
 						}
 					]
+				}
+			]
+		}
+	]
+},
+{
+	"gene_symbol": "DLG4",
+	"gene": "DLG4",
+	"annotations": [
+		{
+			"OMIM_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.omim.org/search?index=entry&start=1&sort=score+desc%2C+prefix_sort+desc&search=DLG4"
+				}
+			]
+		},
+		{
+			"HPO_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://hpo.jax.org/app/browse/search?q=DLG4&navFilter=all"
+				}
+			]
+		},
+		{
+			"Rat Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "RGD:68424"
+				}
+			]
+		},
+		{
+			"Rat_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": []
+				}
+			]
+		},
+		{
+			"Mouse Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "MGI:1277959"
+				}
+			]
+		},
+		{
+			"Model Systems - Mouse - Automated": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "Enables ionotropic glutamate receptor binding activity and scaffold protein binding activity. Involved in several processes, including dendritic spine morphogenesis; locomotory exploration behavior; and neurotransmitter receptor localization to postsynaptic specialization membrane. Acts upstream of or within protein localization to synapse; regulation of long-term neuronal synaptic plasticity; and synaptic vesicle maturation. Located in several cellular components, including axon; postsynaptic density membrane; and synaptic vesicle. Part of AMPA glutamate receptor complex. Is active in glutamatergic synapse. Colocalizes with postsynaptic membrane. Is expressed in central nervous system; dorsal root ganglion; olfactory epithelium; and retina. Used to study Williams-Beuren syndrome and autism spectrum disorder. Human ortholog(s) of this gene implicated in autosomal dominant intellectual developmental disorder. Orthologous to human DLG4 (discs large MAGUK scaffold protein 4)."
+				}
+			]
+		},
+		{
+			"Mouse_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": [
+						{
+							"id": "MGI:5295223",
+							"name": "Dlg4<sup>tm2.1Grnt</sup>/Dlg4<sup>tm2.1Grnt</sup> [background:] involves: 129P2/OlaHsd * C57BL/6J",
+							"displayName": "Dlg4<tm2.1Grnt>/Dlg4<tm2.1Grnt> [background:] involves: 129P2/OlaHsd * C57BL/6J",
+							"phenotypes": [
+								"abnormal anxiety-related response",
+								"abnormal dendritic spine morphology",
+								"abnormal learning/memory/conditioning",
+								"abnormal social investigation",
+								"decreased anxiety-related response",
+								"decreased grip strength",
+								"decreased locomotor activity",
+								"decreased vocalization",
+								"impaired balance",
+								"impaired coordination",
+								"increased circulating corticosterone level",
+								"increased grooming behavior",
+								"increased response to stress-induced hyperthermia"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5295223",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [
+								{
+									"disease": {
+										"id": "DOID:0060041",
+										"name": "autism spectrum disorder",
+										"url": "http://www.disease-ontology.org/?id=DOID:0060041"
+									},
+									"associationType": "IS_MODEL_OF",
+									"diseaseModel": "autism spectrum disorder"
+								},
+								{
+									"disease": {
+										"id": "DOID:1928",
+										"name": "Williams-Beuren syndrome",
+										"url": "http://www.disease-ontology.org/?id=DOID:1928"
+									},
+									"associationType": "IS_MODEL_OF",
+									"diseaseModel": "Williams-Beuren syndrome"
+								}
+							],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "aed48e1d-adeb-42cc-baa3-61b2ccc1ce79",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "a6fef94b-eb56-4b20-9387-76a723038916",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": "2011-11-08T00:00:00-05:00",
+									"evidenceCodes": [
+										{
+											"id": "ECO:0000033",
+											"name": "author statement supported by traceable reference",
+											"displaySynonym": null
+										}
+									]
+								},
+								{
+									"primaryKey": "320dd357-b124-4c79-8b79-ad1940c4f538",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "7801fe2c-c276-42e9-80b7-b336f391948d",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "bf7ba8da-94a0-43ad-9e19-45cb59229f41",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "18514d2d-298d-444b-ac63-9ed953bc3f37",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "f4c6ff03-ddaa-42ca-b2cd-6dcf9b97ba69",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "f7d15585-7acc-4d4e-9778-20662d372adb",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "5dcfd9d3-f4e4-4d10-bf5e-d3179687e271",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "b73f509c-ec72-4559-b456-ea2b7d152bac",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": "2011-11-08T00:00:00-05:00",
+									"evidenceCodes": [
+										{
+											"id": "ECO:0000033",
+											"name": "author statement supported by traceable reference",
+											"displaySynonym": null
+										}
+									]
+								},
+								{
+									"primaryKey": "8859f099-0d88-4f5b-a928-65f0e2d16ba5",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "02f9cea3-b605-457f-a865-9f62f185e3a8",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "81ed6fc7-bd07-4308-8806-ee24774201f8",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "91c41520-39ba-44d4-a054-24bc912c885e",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "b69cea15-4445-4e4b-9057-7f7f62327be4",
+									"publication": {
+										"id": "PMID:20952458",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20952458"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": {
+								"name": "Mus musculus",
+								"shortName": "Mmu",
+								"dataProviderFullName": "Mouse Genome Informatics",
+								"dataProviderShortName": "MGI",
+								"commonNames": "['mouse', 'mmu']",
+								"taxonId": "NCBITaxon:10090"
+							}
+						},
+						{
+							"id": "MGI:3707224",
+							"name": "Dlg3<sup>tm1Grnt</sup>/? Dlg4<sup>tm1Grnt</sup>/Dlg4<sup>tm1Grnt</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg3<tm1Grnt>/? Dlg4<tm1Grnt>/Dlg4<tm1Grnt> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [
+								"perinatal lethality, complete penetrance"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:3707224",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "131e35fc-e854-40bb-8d1f-8d7005109d6f",
+									"publication": {
+										"id": "PMID:17344405",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17344405"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:3707225",
+							"name": "Dlg3<sup>tm1Grnt</sup>/Dlg3<sup>+</sup> Dlg4<sup>tm1Grnt</sup>/Dlg4<sup>tm1Grnt</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg3<tm1Grnt>/Dlg3<+> Dlg4<tm1Grnt>/Dlg4<tm1Grnt> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [
+								"perinatal lethality, incomplete penetrance"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:3707225",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "42d2b37b-9f63-4a2f-b3d8-eee5dfa61eec",
+									"publication": {
+										"id": "PMID:17344405",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17344405"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:3707226",
+							"name": "Dlg3<sup>tm1Grnt</sup>/Dlg3<sup>tm1Grnt</sup> Dlg4<sup>tm1Grnt</sup>/Dlg4<sup>tm1Grnt</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg3<tm1Grnt>/Dlg3<tm1Grnt> Dlg4<tm1Grnt>/Dlg4<tm1Grnt> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [
+								"perinatal lethality, complete penetrance"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:3707226",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "b4ad13ab-0467-4cac-bf9a-f05b51c4270d",
+									"publication": {
+										"id": "PMID:17344405",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17344405"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:5495812",
+							"name": "Dlg4<sup>tm1.1Tdoi</sup>/Dlg4<sup>tm1.1Tdoi</sup> [background:] B6.Cg-Dlg4<sup>tm1.1Tdoi</sup>",
+							"displayName": "Dlg4<tm1.1Tdoi>/Dlg4<tm1.1Tdoi> [background:] B6.Cg-Dlg4<tm1.1Tdoi>",
+							"phenotypes": [
+								"abnormal contextual conditioning behavior",
+								"abnormal discrimination learning",
+								"abnormal learning/memory/conditioning",
+								"abnormal maternal nurturing",
+								"abnormal social investigation",
+								"abnormal spatial learning",
+								"abnormal spatial working memory",
+								"abnormal synaptic plasticity",
+								"abnormal synaptic transmission",
+								"decreased body size",
+								"decreased body weight",
+								"decreased locomotor activity",
+								"decreased neurotransmitter release",
+								"decreased startle reflex",
+								"decreased stereotypic behavior",
+								"enhanced long term potentiation",
+								"enhanced paired-pulse facilitation",
+								"impaired coordination",
+								"increased anxiety-related response",
+								"increased grip strength",
+								"maternal effect",
+								"reduced AMPA-mediated synaptic currents"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5495812",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "ec3ab0b4-737b-4c59-9994-9422422e66e8",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "6e92c027-1bf7-4b45-9b59-32e591dbabd8",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "8d38c370-4d72-47e0-9a51-007a7741bb3a",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "dca2cf21-bf4d-422d-b21c-62a94c5c4c47",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "cd8318b8-bc9d-4486-8278-fa73cfce12ad",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "8dbcf028-4107-4eb9-bed3-28b33d25d9e4",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "bcceb980-d3e8-470b-9a30-4a70b7e89a29",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "0b18978d-9f96-437a-9469-c1e8f2c2d6ae",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "093de463-627c-4626-88cf-ff41de2e575c",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "27d9d178-8de1-48b3-9942-a243a81eb62e",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "28f52dad-9463-499f-8561-499bbb4bace6",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "9f03490c-df15-436b-a818-25ff21b8165c",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "e1ab1d91-fddd-448c-976b-5dcc2048f8e2",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "f0f6153b-2346-46be-93bf-8284f4934551",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "5ce8ddcc-9c02-4cd1-b1c1-a0468f6f8382",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "57173980-2fa1-4cbf-b6c3-fe1eb40c2d38",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "5ed11751-3d65-4a39-89b0-f67f34c68fb4",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "4209c1fc-5a81-4efa-9b28-9a27558e5430",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "e95356db-f2e6-4c92-8e54-d5cdb45c4b0b",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "63829c1a-1029-4871-ad03-27fcb2bd8d78",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "3c82cb50-851a-47b9-9f31-425e63238c28",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "57344ccc-1f0c-4670-8f82-5c572b18109c",
+									"publication": {
+										"id": "PMID:23268962",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23268962"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:6262287",
+							"name": "Dlg4<sup>tm1e(EUCOMM)Wtsi</sup>/Dlg4<sup>tm1e(EUCOMM)Wtsi</sup> [background:] C57BL/6N-Dlg4<sup>tm1e(EUCOMM)Wtsi</sup>/Wtsi",
+							"displayName": "Dlg4<tm1e(EUCOMM)Wtsi>/Dlg4<tm1e(EUCOMM)Wtsi> [background:] C57BL/6N-Dlg4<tm1e(EUCOMM)Wtsi>/Wtsi",
+							"phenotypes": [
+								"decreased grip strength",
+								"decreased total body fat amount",
+								"increased bone mineral content",
+								"increased circulating sodium level",
+								"increased lean body mass",
+								"tremors"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:6262287",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "97f31409-bc67-41d3-ba9e-e0ef3b16b7db",
+									"publication": {
+										"id": "MGI:5576271",
+										"url": "http://www.informatics.jax.org/"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "83ca3cf3-50fe-422f-bc3e-e28bed84a76d",
+									"publication": {
+										"id": "MGI:5576271",
+										"url": "http://www.informatics.jax.org/"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "de791b5f-e58f-48c7-b1e8-8d2aad8fd095",
+									"publication": {
+										"id": "MGI:5576271",
+										"url": "http://www.informatics.jax.org/"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "7dff1888-4571-4dff-a729-1e1e73a19a10",
+									"publication": {
+										"id": "MGI:5576271",
+										"url": "http://www.informatics.jax.org/"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "07939601-1ab0-46e2-9efb-916e6e0e740b",
+									"publication": {
+										"id": "MGI:5576271",
+										"url": "http://www.informatics.jax.org/"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "eed3cbf7-9596-4765-840d-8dcad81089bb",
+									"publication": {
+										"id": "MGI:5576271",
+										"url": "http://www.informatics.jax.org/"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:5641694",
+							"name": "Dlg4<sup>tm1Grnt</sup>/Dlg4<sup>tm1Grnt</sup> [background:] involves: 129P2/OlaHsd * C57BL/6JIco",
+							"displayName": "Dlg4<tm1Grnt>/Dlg4<tm1Grnt> [background:] involves: 129P2/OlaHsd * C57BL/6JIco",
+							"phenotypes": [
+								"abnormal sebaceous gland morphology"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:5641694",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "c7225f85-c918-42ca-be9a-94dca66eb45a",
+									"publication": {
+										"id": "PMID:24721909",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/24721909"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:2651586",
+							"name": "Dlg4<sup>tm1Grnt</sup>/Dlg4<sup>tm1Grnt</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg4<tm1Grnt>/Dlg4<tm1Grnt> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [
+								"abnormal CNS synaptic transmission",
+								"abnormal forebrain morphology",
+								"abnormal hippocampus pyramidal cell morphology",
+								"abnormal pain threshold",
+								"abnormal spatial learning",
+								"abnormal striatum morphology",
+								"allodynia",
+								"decreased body size",
+								"enhanced long term potentiation",
+								"enhanced paired-pulse facilitation",
+								"postnatal lethality, incomplete penetrance"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:2651586",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "edad6ca7-ecca-457d-8f23-b69773e0c3c0",
+									"publication": {
+										"id": "PMID:9853749",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/9853749"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "547ad326-13a3-452b-8848-4da9ba43e2c7",
+									"publication": {
+										"id": "PMID:12427827",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/12427827"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "c773a0f3-b31a-4e43-bdba-84d39858ce2d",
+									"publication": {
+										"id": "PMID:9853749",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/9853749"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "0cf9cbb1-96a0-458f-8fd7-34e95dbe1309",
+									"publication": {
+										"id": "PMID:16677619",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/16677619"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "3de9fa06-02f9-4b6d-8e18-7f0c392a6c61",
+									"publication": {
+										"id": "PMID:12593798",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/12593798"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "41414abc-c612-45ae-9ec3-3706718225ab",
+									"publication": {
+										"id": "PMID:12593798",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/12593798"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "6668e2db-b935-4b10-8594-9d09b15ef169",
+									"publication": {
+										"id": "PMID:9853749",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/9853749"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "936caf1c-1553-44fe-874e-2e9476698dfe",
+									"publication": {
+										"id": "PMID:16677619",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/16677619"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "275959c1-caa9-477d-a064-f92352c7536a",
+									"publication": {
+										"id": "PMID:9853749",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/9853749"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "44d4eb1d-6b80-4556-9609-cc673322fd00",
+									"publication": {
+										"id": "PMID:9853749",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/9853749"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "00598446-14da-4b0d-a3ac-a384ad10d51a",
+									"publication": {
+										"id": "PMID:16677619",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/16677619"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "3e5e2e96-8e1a-474e-b7a1-1b7df5ab84b2",
+									"publication": {
+										"id": "PMID:12427827",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/12427827"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "fcf93f14-c0ea-43cd-8938-5cfd2e1d4a94",
+									"publication": {
+										"id": "PMID:9853749",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/9853749"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:3581308",
+							"name": "Dlg4<sup>tm1Grnt</sup>/Dlg4<sup>tm1Grnt</sup> Syngap1<sup>tm1Grnt</sup>/Syngap1<sup>+</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg4<tm1Grnt>/Dlg4<tm1Grnt> Syngap1<tm1Grnt>/Syngap1<+> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [
+								"enhanced long term potentiation"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:3581308",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "ab71d2cb-6009-41ba-afd2-92d530c3b88d",
+									"publication": {
+										"id": "PMID:12427827",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/12427827"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:3700390",
+							"name": "Dlg4<sup>tm1Rlh</sup>/Dlg4<sup>tm1Rlh</sup> [background:] involves: 129S1/Sv * 129X1/SvJ * C57BL/6",
+							"displayName": "Dlg4<tm1Rlh>/Dlg4<tm1Rlh> [background:] involves: 129S1/Sv * 129X1/SvJ * C57BL/6",
+							"phenotypes": [
+								"abnormal AMPA-mediated synaptic currents",
+								"abnormal NMDA-mediated synaptic currents",
+								"abnormal glutamate-mediated receptor currents",
+								"abnormal innervation",
+								"enhanced long term potentiation"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:3700390",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "89cae675-70bb-476b-a6f3-bdd3015965d4",
+									"publication": {
+										"id": "PMID:17148601",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17148601"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "63e563da-36bb-4793-b573-97d28248176b",
+									"publication": {
+										"id": "PMID:17148601",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17148601"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "27a85da3-af39-4f38-884b-0477d1b06a1a",
+									"publication": {
+										"id": "PMID:17148601",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17148601"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "e2e86ca7-dca8-463d-a817-6ce2a27a8403",
+									"publication": {
+										"id": "PMID:17148601",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17148601"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "95af5ed9-8b75-4169-ad77-65824c4a4adb",
+									"publication": {
+										"id": "PMID:17148601",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/17148601"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:3852394",
+							"name": "Dlg4<sup>tm2.1Grnt</sup>/Dlg4<sup>tm2.1Grnt</sup> [background:] involves: 129P2/OlaHsd",
+							"displayName": "Dlg4<tm2.1Grnt>/Dlg4<tm2.1Grnt> [background:] involves: 129P2/OlaHsd",
+							"phenotypes": [
+								"decreased locomotor activity",
+								"decreased vertical activity",
+								"enhanced behavioral response to cocaine",
+								"enhanced long term potentiation",
+								"impaired behavioral response to cocaine"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:3852394",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "c0597f38-7f4b-460a-a626-43249bdf02d0",
+									"publication": {
+										"id": "PMID:14980210",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/14980210"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "a3be60f9-6933-4f78-9bab-bfc122ef8be2",
+									"publication": {
+										"id": "PMID:14980210",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/14980210"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "c8b6782f-a965-47c4-9056-c87c64eafdde",
+									"publication": {
+										"id": "PMID:14980210",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/14980210"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "d525ec33-2ec0-4493-9223-d6a267dfb51b",
+									"publication": {
+										"id": "PMID:14980210",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/14980210"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "3811cfd9-faeb-48fb-bd73-305e42af98b7",
+									"publication": {
+										"id": "PMID:14980210",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/14980210"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:4888258",
+							"name": "Dlg4<sup>tm4.1Grnt</sup>/Dlg4<sup>tm4.1Grnt</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg4<tm4.1Grnt>/Dlg4<tm4.1Grnt> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [
+								"abnormal nociception after inflammation"
+							],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:4888258",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "a60accc2-9b37-4d1e-a4d9-590c1d3dad18",
+									"publication": {
+										"id": "PMID:20467438",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/20467438"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "MGI:4359771",
+							"name": "Dlg4<sup>tm3.1Grnt</sup>/Dlg4<sup>tm3.1Grnt</sup> [background:] involves: 129P2/OlaHsd * MF1",
+							"displayName": "Dlg4<tm3.1Grnt>/Dlg4<tm3.1Grnt> [background:] involves: 129P2/OlaHsd * MF1",
+							"phenotypes": [],
+							"url": "http://www.informatics.jax.org/allele/genoview/MGI:4359771",
+							"type": "genotype",
+							"crossReference": null,
+							"source": {
+								"name": "MGI",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [],
+							"conditions": {},
+							"conditionModifiers": {},
+							"alleles": [
+								{
+									"id": "MGI:4359766",
+									"symbol": "Dlg4<sup>tm3.1Grnt</sup>",
+									"species": {
+										"name": "Mus musculus",
+										"shortName": "Mmu",
+										"dataProviderFullName": "Mouse Genome Informatics",
+										"dataProviderShortName": "MGI",
+										"commonNames": "['mouse', 'mmu']",
+										"taxonId": "NCBITaxon:10090"
+									},
+									"synonyms": [],
+									"secondaryIds": [],
+									"symbolText": "Dlg4<tm3.1Grnt>",
+									"hasDisease": false,
+									"hasPhenotype": false,
+									"category": "allele",
+									"type": "allele",
+									"modCrossRefCompleteUrl": "",
+									"variants": [],
+									"crossReferenceMap": {}
+								}
+							],
+							"sequenceTargetingReagents": [],
+							"species": {
+								"name": "Mus musculus",
+								"shortName": "Mmu",
+								"dataProviderFullName": "Mouse Genome Informatics",
+								"dataProviderShortName": "MGI",
+								"commonNames": "['mouse', 'mmu']",
+								"taxonId": "NCBITaxon:10090"
+							}
+						}
+					]
+				}
+			]
+		},
+		{
+			"Entrez Gene Id": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": 1742
+				}
+			]
+		},
+		{
+			"Ensembl Gene Id": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "ENSG00000132535"
+				}
+			]
+		},
+		{
+			"HGNC_ID": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "HGNC:2903"
+				}
+			]
+		},
+		{
+			"Gene Summary": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "This gene encodes a member of the membrane-associated guanylate kinase (MAGUK) family. It heteromultimerizes with another MAGUK protein, DLG2, and is recruited into NMDA receptor and potassium channel clusters. These two MAGUK proteins may interact at postsynaptic sites to form a multimeric scaffold for the clustering of receptors, ion channels, and associated signaling proteins. Multiple transcript variants encoding different isoforms have been found for this gene. [provided by RefSeq, Jul 2008]"
+				}
+			]
+		},
+		{
+			"ClinGen_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://search.clinicalgenome.org/kb/genes/HGNC:2903"
+				}
+			]
+		},
+		{
+			"NCBI_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=1742"
+				}
+			]
+		},
+		{
+			"gnomAD_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://gnomad.broadinstitute.org/gene/ENSG00000132535?dataset=gnomad_r2_1"
+				}
+			]
+		},
+		{
+			"OMIM": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"Intellectual developmental disorder 62"
+					]
+				}
+			]
+		},
+		{
+			"HPO": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"HP:0003593: Infantile onset",
+						"HP:0012771: Increased arm span",
+						"HP:0001763: Pes planus",
+						"HP:0001250: Seizure",
+						"HP:0001166: Arachnodactyly",
+						"HP:0000006: Autosomal dominant inheritance",
+						"HP:0001388: Joint laxity",
+						"HP:0002650: Scoliosis",
+						"HP:0000486: Strabismus",
+						"HP:0001065: Striae distensae",
+						"HP:0001519: Disproportionate tall stature",
+						"HP:0006855: Cerebellar vermis atrophy",
+						"HP:0000729: Autistic behavior",
+						"HP:0001249: Intellectual disability"
+					]
+				}
+			]
+		},
+		{
+			"Model Systems - Rat": [
+				{
+					"data_source": "Aliance Genome",
+					"version": "",
+					"value": "Enables several functions, including PDZ domain binding activity; enzyme binding activity; and signaling receptor binding activity. A structural constituent of postsynaptic density. Involved in several processes, including modulation of chemical synaptic transmission; positive regulation of cellular component organization; and postsynapse organization. Located in several cellular components, including dendrite; juxtaparanode region of axon; and postsynaptic density. Is active in glutamatergic synapse. Colocalizes with postsynaptic membrane. Biomarker of Parkinson's disease and temporal lobe epilepsy. Human ortholog(s) of this gene implicated in autosomal dominant intellectual developmental disorder. Orthologous to human DLG4 (discs large MAGUK scaffold protein 4); PARTICIPATES IN glutamate signaling pathway; Huntington's disease pathway; INTERACTS WITH (S)-nicotine; 17beta-estradiol; 2,2',4,4',5,5'-hexachlorobiphenyl."
+				}
+			]
+		}
+	]
+},
+{
+	"gene_symbol": "G6PD",
+	"gene": "G6PD",
+	"annotations": [
+		{
+			"OMIM_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.omim.org/search?index=entry&start=1&sort=score+desc%2C+prefix_sort+desc&search=G6PD"
+				}
+			]
+		},
+		{
+			"HPO_gene_search_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://hpo.jax.org/app/browse/search?q=G6PD&navFilter=all"
+				}
+			]
+		},
+		{
+			"Rat Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "RGD:2645"
+				}
+			]
+		},
+		{
+			"Rat_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": []
+				}
+			]
+		},
+		{
+			"Zebrafish Gene Identifier": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "ZFIN:ZDB-GENE-070508-4"
+				}
+			]
+		},
+		{
+			"Model Systems - Zebrafish - Automated": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "Enables UDP-glucose 6-dehydrogenase activity and glucose-6-phosphate dehydrogenase activity. Acts upstream of or within epiboly. Predicted to be active in cytosol. Used to study hemolytic anemia. Human ortholog(s) of this gene implicated in several diseases, including anemia (multiple); cerebrovascular disease; favism; malaria (multiple); and neonatal jaundice. Orthologous to human G6PD (glucose-6-phosphate dehydrogenase)."
+				}
+			]
+		},
+		{
+			"Zebrafish_Alliance_Genome_Models": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": [
+						{
+							"id": "ZFIN:ZDB-FISH-190605-7",
+							"name": "AB + CRISPR1-g6pd",
+							"displayName": "AB + CRISPR1-g6pd",
+							"phenotypes": [
+								"glucose-6-phosphate dehydrogenase activity decreased occurrence, abnormal",
+								"pericardium edematous, abnormal",
+								"whole organism NADPH decreased amount, abnormal",
+								"whole organism reactive oxygen species increased amount, abnormal"
+							],
+							"url": "https://zfin.org/ZDB-FISH-190605-7",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [
+								{
+									"disease": {
+										"id": "DOID:583",
+										"name": "hemolytic anemia",
+										"url": "http://www.disease-ontology.org/?id=DOID:583"
+									},
+									"associationType": "IS_MODEL_OF",
+									"diseaseModel": "hemolytic anemia"
+								}
+							],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "4e825cfc-79ea-4151-a17a-c5f1e7f7a744",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "5cc5fabd-b789-4e66-a7a3-7031e3a10380",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": "2023-03-07T04:02:14-08:00",
+									"evidenceCodes": [
+										{
+											"id": "ECO:0000304",
+											"name": "author statement supported by traceable reference used in manual assertion",
+											"displaySynonym": null
+										}
+									]
+								},
+								{
+									"primaryKey": "aacdc40b-1f06-45cd-95bd-9d6d3be13ef9",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "83de1e53-6350-4424-b3ea-faf5ceddece1",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "fb0d548a-fcf7-4633-b7f7-95a04668c39f",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "standard conditionsZECO:0000103",
+										"conditionStatement": "standard conditions",
+										"term": {
+											"id": "ZECO:0000103",
+											"name": "standard conditions"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": {
+								"name": "Danio rerio",
+								"shortName": "Dre",
+								"dataProviderFullName": "Zebrafish Information Network",
+								"dataProviderShortName": "ZFIN",
+								"commonNames": "['zebrafish', 'fish', 'dre']",
+								"taxonId": "NCBITaxon:7955"
+							}
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-190605-7",
+							"name": "AB + CRISPR1-g6pd",
+							"displayName": "AB + CRISPR1-g6pd",
+							"phenotypes": [],
+							"url": "https://zfin.org/ZDB-FISH-190605-7",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [
+								{
+									"disease": {
+										"id": "DOID:583",
+										"name": "hemolytic anemia",
+										"url": "http://www.disease-ontology.org/?id=DOID:583"
+									},
+									"associationType": "IS_MODEL_OF",
+									"diseaseModel": "hemolytic anemia"
+								}
+							],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "670ccda5-05d9-454a-9d1a-c9c66bb1c16e",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": "2023-03-07T04:02:17-08:00",
+									"evidenceCodes": [
+										{
+											"id": "ECO:0000304",
+											"name": "author statement supported by traceable reference used in manual assertion",
+											"displaySynonym": null
+										}
+									]
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "chemical treatment: chloroquineZECO:0000111CHEBI:3638",
+										"conditionStatement": "chemical treatment: chloroquine",
+										"term": {
+											"id": "ZECO:0000111",
+											"name": "chemical treatment"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": {
+								"name": "Danio rerio",
+								"shortName": "Dre",
+								"dataProviderFullName": "Zebrafish Information Network",
+								"dataProviderShortName": "ZFIN",
+								"commonNames": "['zebrafish', 'fish', 'dre']",
+								"taxonId": "NCBITaxon:7955"
+							}
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-190605-7",
+							"name": "AB + CRISPR1-g6pd",
+							"displayName": "AB + CRISPR1-g6pd",
+							"phenotypes": [
+								"glucose-6-phosphate dehydrogenase activity decreased occurrence, abnormal"
+							],
+							"url": "https://zfin.org/ZDB-FISH-190605-7",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "76df1f42-d552-47db-b9a9-daa2011a6573",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "chemical treatment N,N'-[disulfanediyldi(ethane-2,1-diyl)]bis[2-(1H-indol-3-yl)ethan-1-amine]ZECO:0000111CHEBI:143872",
+										"conditionStatement": "chemical treatment N,N'-[disulfanediyldi(ethane-2,1-diyl)]bis[2-(1H-indol-3-yl)ethan-1-amine]",
+										"term": {
+											"id": "ZECO:0000111",
+											"name": "chemical treatment"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-190605-7",
+							"name": "AB + CRISPR1-g6pd",
+							"displayName": "AB + CRISPR1-g6pd",
+							"phenotypes": [
+								"blood accumulation pericardial region, abnormal",
+								"pericardium edematous, abnormal",
+								"whole organism reactive oxygen species increased amount, exacerbated"
+							],
+							"url": "https://zfin.org/ZDB-FISH-190605-7",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "1588c109-8bac-4e95-b2a8-d812130df941",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "56b07b02-ca7a-4954-88d6-e3b27c10fd49",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "4f56cdf2-9797-4d9d-9594-41d77371f392",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "chemical treatment chloroquineZECO:0000111CHEBI:3638",
+										"conditionStatement": "chemical treatment chloroquine",
+										"term": {
+											"id": "ZECO:0000111",
+											"name": "chemical treatment"
+										}
+									},
+									{
+										"primaryKey": "chemical treatment N,N'-[disulfanediyldi(ethane-2,1-diyl)]bis[2-(1H-indol-3-yl)ethan-1-amine]ZECO:0000111CHEBI:143872",
+										"conditionStatement": "chemical treatment N,N'-[disulfanediyldi(ethane-2,1-diyl)]bis[2-(1H-indol-3-yl)ethan-1-amine]",
+										"term": {
+											"id": "ZECO:0000111",
+											"name": "chemical treatment"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-190605-7",
+							"name": "AB + CRISPR1-g6pd",
+							"displayName": "AB + CRISPR1-g6pd",
+							"phenotypes": [
+								"glucose-6-phosphate dehydrogenase activity decreased occurrence, abnormal",
+								"pericardium edematous, exacerbated",
+								"whole organism reactive oxygen species increased amount, exacerbated"
+							],
+							"url": "https://zfin.org/ZDB-FISH-190605-7",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "3c4b26df-2c3f-47bf-b06a-35f7614aae0a",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "2c9249d1-1017-458b-820a-196682b6dbd2",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "b15d6d42-fde2-42ab-bc1b-de2deb473963",
+									"publication": {
+										"id": "PMID:30279493",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/30279493"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "chemical treatment chloroquineZECO:0000111CHEBI:3638",
+										"conditionStatement": "chemical treatment chloroquine",
+										"term": {
+											"id": "ZECO:0000111",
+											"name": "chemical treatment"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-210402-8",
+							"name": "spint1a<sup>hi2217Tg/hi2217Tg</sup> + CRISPR2-g6pd",
+							"displayName": "spint1a<hi2217Tg/hi2217Tg> + CRISPR2-g6pd",
+							"phenotypes": [
+								"caudal fin keratinocyte amount, ameliorated",
+								"caudal fin melanocyte amount, ameliorated"
+							],
+							"url": "https://zfin.org/ZDB-FISH-210402-8",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "85bd7e82-6e38-41f2-b18a-0ebc80921b71",
+									"publication": {
+										"id": "PMID:32126244",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/32126244"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "a99b838a-4be6-478e-a924-f8a73af6def0",
+									"publication": {
+										"id": "PMID:32126244",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/32126244"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "standard conditionsZECO:0000103",
+										"conditionStatement": "standard conditions",
+										"term": {
+											"id": "ZECO:0000103",
+											"name": "standard conditions"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-210401-7",
+							"name": "spint1a<sup>hi2217Tg/hi2217Tg</sup>; nc1Tg + CRISPR2-g6pd",
+							"displayName": "spint1a<hi2217Tg/hi2217Tg>; nc1Tg + CRISPR2-g6pd",
+							"phenotypes": [
+								"integument I-kappaB kinase/NF-kappaB signaling increased process quality, abnormal"
+							],
+							"url": "https://zfin.org/ZDB-FISH-210401-7",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "5a7ef6e3-803d-4552-a62d-e4f2669434c5",
+									"publication": {
+										"id": "PMID:32126244",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/32126244"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "standard conditionsZECO:0000103",
+										"conditionStatement": "standard conditions",
+										"term": {
+											"id": "ZECO:0000103",
+											"name": "standard conditions"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-210401-5",
+							"name": "spint1a<sup>hi2217Tg/hi2217Tg</sup>; nz50Tg + CRISPR2-g6pd",
+							"displayName": "spint1a<hi2217Tg/hi2217Tg>; nz50Tg + CRISPR2-g6pd",
+							"phenotypes": [
+								"integument hydrogen peroxide amount, ameliorated",
+								"integument neutrophil amount, ameliorated"
+							],
+							"url": "https://zfin.org/ZDB-FISH-210401-5",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "3a214b94-acf7-4378-b91a-2f23ac3bb1da",
+									"publication": {
+										"id": "PMID:32126244",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/32126244"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "5409330b-b5d7-4121-99bc-4ef95a689d4a",
+									"publication": {
+										"id": "PMID:32126244",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/32126244"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "standard conditionsZECO:0000103",
+										"conditionStatement": "standard conditions",
+										"term": {
+											"id": "ZECO:0000103",
+											"name": "standard conditions"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-180612-16",
+							"name": "TU + MO1-g6pd + MO2-g6pd",
+							"displayName": "TU + MO1-g6pd + MO2-g6pd",
+							"phenotypes": [
+								"epiboly decreased rate, abnormal",
+								"heart edematous, abnormal",
+								"whole organism <i>cdh2</i> expression increased amount, abnormal",
+								"whole organism <i>snai1b</i> expression increased amount, abnormal",
+								"whole organism cell surface shape, abnormal"
+							],
+							"url": "https://zfin.org/ZDB-FISH-180612-16",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "cff0f301-9027-45cc-b5d8-817494e3bd73",
+									"publication": {
+										"id": "PMID:29317613",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/29317613"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "9bba09b3-4cda-4c7d-939f-362611a7159a",
+									"publication": {
+										"id": "PMID:29317613",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/29317613"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "cc957a38-a36f-4620-b61f-143c80c20177",
+									"publication": {
+										"id": "PMID:29317613",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/29317613"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "9417aa0d-d5b7-4a0f-aad4-6a5d6075272b",
+									"publication": {
+										"id": "PMID:29317613",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/29317613"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "a39058a9-7226-4d48-8cb7-45f02a97f16a",
+									"publication": {
+										"id": "PMID:29317613",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/29317613"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "standard conditionsZECO:0000103",
+										"conditionStatement": "standard conditions",
+										"term": {
+											"id": "ZECO:0000103",
+											"name": "standard conditions"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-150901-29210",
+							"name": "WT + MO1-g6pd + MO2-g6pd",
+							"displayName": "WT + MO1-g6pd + MO2-g6pd",
+							"phenotypes": [
+								"nucleate erythrocyte decreased amount, abnormal",
+								"pericardium edematous, abnormal",
+								"pronephros edematous, abnormal"
+							],
+							"url": "https://zfin.org/ZDB-FISH-150901-29210",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "c95e24c8-ba87-4ebc-babc-23d6420942fb",
+									"publication": {
+										"id": "PMID:23603363",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23603363"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "c1b3ecd9-6a72-43cb-9884-dd87399657bd",
+									"publication": {
+										"id": "PMID:23603363",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23603363"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "7f3b55bd-2563-4577-9cf4-84d89f63c663",
+									"publication": {
+										"id": "PMID:23603363",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/23603363"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "standard conditionsZECO:0000103",
+										"conditionStatement": "standard conditions",
+										"term": {
+											"id": "ZECO:0000103",
+											"name": "standard conditions"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						},
+						{
+							"id": "ZFIN:ZDB-FISH-150901-29210",
+							"name": "WT + MO1-g6pd + MO2-g6pd",
+							"displayName": "WT + MO1-g6pd + MO2-g6pd",
+							"phenotypes": [
+								"nucleate erythrocyte lysed, abnormal",
+								"whole organism edematous, abnormal"
+							],
+							"url": "https://zfin.org/ZDB-FISH-150901-29210",
+							"type": "affected_genomic_model",
+							"crossReference": null,
+							"source": {
+								"name": "ZFIN",
+								"url": null
+							},
+							"diseaseAssociationType": null,
+							"diseaseModels": [],
+							"publicationEvidenceCodes": [
+								{
+									"primaryKey": "443d9652-6a3c-4504-87dd-abaf40748d06",
+									"publication": {
+										"id": "PMID:33154437",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/33154437"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								},
+								{
+									"primaryKey": "dac823e2-e90f-4792-bdd1-44ad7d7ad161",
+									"publication": {
+										"id": "PMID:33154437",
+										"url": "https://www.ncbi.nlm.nih.gov/pubmed/33154437"
+									},
+									"dateAssigned": null,
+									"evidenceCodes": []
+								}
+							],
+							"conditions": {
+								"has_condition": [
+									{
+										"primaryKey": "chemical treatment by environment chemical substanceZECO:0000238CHEBI:59999",
+										"conditionStatement": "chemical treatment by environment chemical substance",
+										"term": {
+											"id": "ZECO:0000238",
+											"name": "chemical treatment by environment"
+										}
+									}
+								]
+							},
+							"conditionModifiers": {},
+							"alleles": [],
+							"sequenceTargetingReagents": [],
+							"species": null
+						}
+					]
+				}
+			]
+		},
+		{
+			"Entrez Gene Id": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": 2539
+				}
+			]
+		},
+		{
+			"Ensembl Gene Id": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "ENSG00000160211"
+				}
+			]
+		},
+		{
+			"HGNC_ID": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": "HGNC:4057"
+				}
+			]
+		},
+		{
+			"Gene Summary": [
+				{
+					"data_source": "Alliance Genome",
+					"version": "",
+					"value": "This gene encodes glucose-6-phosphate dehydrogenase. This protein is a cytosolic enzyme encoded by a housekeeping X-linked gene whose main function is to produce NADPH, a key electron donor in the defense against oxidizing agents and in reductive biosynthetic reactions. G6PD is remarkable for its genetic diversity. Many variants of G6PD, mostly produced from missense mutations, have been described with wide ranging levels of enzyme activity and associated clinical symptoms. G6PD deficiency may cause neonatal jaundice, acute hemolysis, or severe chronic non-spherocytic hemolytic anemia. Two transcript variants encoding different isoforms have been found for this gene. [provided by RefSeq, Jul 2008]"
+				}
+			]
+		},
+		{
+			"ClinGen_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://search.clinicalgenome.org/kb/genes/HGNC:4057"
+				}
+			]
+		},
+		{
+			"NCBI_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=2539"
+				}
+			]
+		},
+		{
+			"gnomAD_gene_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://gnomad.broadinstitute.org/gene/ENSG00000160211?dataset=gnomad_r2_1"
+				}
+			]
+		},
+		{
+			"OMIM": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"Hemolytic anemia, G6PD deficient (favism)"
+					]
+				}
+			]
+		},
+		{
+			"HPO": [
+				{
+					"data_source": "HPO",
+					"version": "",
+					"value": [
+						"HP:0003593: Infantile onset",
+						"HP:0410179: Decreased glucose-6-phosphate dehydrogenase level in blood",
+						"HP:0000952: Jaundice",
+						"HP:0004447: Poikilocytosis",
+						"HP:0000980: Pallor",
+						"HP:0001974: Leukocytosis",
+						"HP:0011463: Childhood onset",
+						"HP:0002027: Abdominal pain",
+						"HP:0001923: Reticulocytosis",
+						"HP:0006579: Prolonged neonatal jaundice",
+						"HP:0001744: Splenomegaly",
+						"HP:0020082: Heinz bodies",
+						"HP:0004814: Fava bean-induced hemolytic anemia",
+						"HP:0011273: Anisocytosis",
+						"HP:0008282: Unconjugated hyperbilirubinemia",
+						"HP:0003621: Juvenile onset",
+						"HP:0003596: Middle age onset",
+						"HP:0003577: Congenital onset",
+						"HP:0001423: X-linked dominant inheritance",
+						"HP:0003641: Hemoglobinuria",
+						"HP:0001945: Fever",
+						"HP:0011462: Young adult onset"
+					]
+				}
+			]
+		},
+		{
+			"Model Systems - Rat": [
+				{
+					"data_source": "Aliance Genome",
+					"version": "",
+					"value": "Enables NADP binding activity; glucose binding activity; and glucose-6-phosphate dehydrogenase activity. Involved in several processes, including negative regulation of cell growth involved in cardiac muscle cell development; pentose-phosphate shunt, oxidative branch; and positive regulation of calcium ion transmembrane transport via high voltage-gated calcium channel. Located in cytosol and nucleus. Used to study cataract and transient cerebral ischemia. Biomarker of several diseases, including artery disease (multiple); hepatic encephalopathy; hyperhomocysteinemia; obesity; and phenylketonuria. Human ortholog(s) of this gene implicated in several diseases, including anemia (multiple); cerebrovascular disease; favism; malaria (multiple); and neonatal jaundice. Orthologous to human G6PD (glucose-6-phosphate dehydrogenase); PARTICIPATES IN pentose phosphate pathway; pentose phosphate pathway - oxidative phase; ribose 5-phosphate isomerase deficiency pathway; INTERACTS WITH (+)-schisandrin B; (+)-taxifolin; (R)-noradrenaline."
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_001365.4:c.1039del",
+	"chromosome": "",
+	"position": "",
+	"reference": "",
+	"alternate": "",
+	"build": "GRCh37",
+	"transcripts": [
+		{
+			"transcript_id": "NM_001128827.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001128827.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001321074.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001321074.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001321075.3",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001321075.3"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001321076.3",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001321076.3"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001321077.3",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001321077.3"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001365.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001365.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001369566.3",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001369566.3"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"frameshift_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "HIGH"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NR_135527.1",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NR_135527.1"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": null
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"non_coding_transcript_exon_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODIFIER"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": null
+				}
+			]
+		}
+	]
+},
+{
+	"hgvs_variant": "NM_001360016.2:c.563C>T",
+	"chromosome": "",
+	"position": "",
+	"reference": "",
+	"alternate": "",
+	"build": "GRCh37",
+	"transcripts": [
+		{
+			"transcript_id": "NM_000402.4",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_000402.4"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "benign"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.018
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001042351.3",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001042351.3"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "benign"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.03
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		},
+		{
+			"transcript_id": "NM_001360016.2",
+			"annotations": [
+				{
+					"transcript_id": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "NM_001360016.2"
+						}
+					]
+				},
+				{
+					"Polyphen Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "benign"
+						}
+					]
+				},
+				{
+					"Polyphen Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0.03
+						}
+					]
+				},
+				{
+					"SIFT Prediction": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "deleterious"
+						}
+					]
+				},
+				{
+					"SIFT Score": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": 0
+						}
+					]
+				},
+				{
+					"Consequences": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": [
+								"missense_variant"
+							]
+						}
+					]
+				},
+				{
+					"Impact": [
+						{
+							"data_source": "Ensembl",
+							"version": "",
+							"value": "MODERATE"
+						}
+					]
+				}
+			]
+		}
+	],
+	"annotations": [
+		{
+			"ClinVar_Variantion_Id": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "100057"
+				}
+			]
+		},
+		{
+			"CADD": [
+				{
+					"data_source": "Ensembl",
+					"version": "",
+					"value": 24.5
+				}
+			]
+		},
+		{
+			"ClinVar_variant_url": [
+				{
+					"data_source": "Rosalution",
+					"version": "",
+					"value": "https://www.ncbi.nlm.nih.gov/clinvar/variation/100057"
 				}
 			]
 		}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

<!-- Delete the tasks from the above list that are Not Applicable for your pull request -->

## Pull Request Details

[https://www.wrike.com/open.htm?id=1131312019](https://www.wrike.com/open.htm?id=1131312019)

Changes made:

- Updated the fixtures for CPAM0084, now properly has genomic units imported when running docker build

**To Review:**
- [ ] Static Analysis by Reviewer
- [ ] Do the genes in CPAM0084 have annotations after a fresh build?
  ``` bash
  # From root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker-compose up --build
  ```
  - Go to `http://local.rosalution.cgds/rosalution`
  - Login with `developer`
  - Click on CPAM0084
  - Click on either DLG4 or G6PD gene link
  - Do annotations show up for DLG4 and G6PD?
- [ ] All Github Actions checks have passed.

![Screenshot 2023-06-12 at 10 37 36 AM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/b90b156a-da93-4b68-95d1-bfd9220088df)

![Screenshot 2023-06-12 at 10 37 50 AM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/a4f3b49c-531b-406b-bfcc-8655f814624a)