### PR TITLE
Status rollup filter

### DIFF
--- a/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="legend">
     <!-- Annotating -->
-    <div class="status" @click="toggleFilter('annotating')">
+    <div class="status" @click="toggleFilter('annotation')">
       <font-awesome-icon icon="asterisk" size="lg" :style="{
-        color: isFiltered('annotating')
+        color: isFiltered('annotation')
           ? 'var(--rosalution-grey-300)'
           : 'var(--rosalution-status-annotation)'
       }" />
-      <p :style="{ color: isFiltered('annotating') ? 'var(--rosalution-grey-300)' : '' }">Annotating</p>
+      <p :style="{ color: isFiltered('annotation') ? 'var(--rosalution-grey-300)' : '' }">Annotating</p>
     </div>
 
     <!-- Ready -->
@@ -31,13 +31,13 @@
     </div>
 
     <!-- On Hold -->
-    <div class="status" @click="toggleFilter('onHold')">
+    <div class="status" @click="toggleFilter('on-hold')">
       <font-awesome-icon icon="pause" size="lg" :style="{
-        color: isFiltered('onHold')
+        color: isFiltered('on-hold')
           ? 'var(--rosalution-grey-300)'
           : 'var(--rosalution-status-on-hold)'
       }" />
-      <p :style="{ color: isFiltered('onHold') ? 'var(--rosalution-grey-300)' : '' }">On Hold</p>
+      <p :style="{ color: isFiltered('on-hold') ? 'var(--rosalution-grey-300)' : '' }">On Hold</p>
     </div>
 
     <!-- Approved -->
@@ -79,20 +79,16 @@ export default {
   methods: {
     toggleFilter(status) {
       if (this.isFiltered(status)) {
-        // If the status is already filtered, remove it from the array
         const index = this.filteredStatuses.indexOf(status);
         if (index !== -1) {
           this.filteredStatuses.splice(index, 1);
         }
       } else {
-        // If the status is not filtered, add it to the array
         this.filteredStatuses.push(status);
       }
-      // Emit the filtered statuses
       this.$emit('filtered-statuses', this.filteredStatuses);
     },
     isFiltered(status) {
-      // A status is filtered if it's in the array
       return this.filteredStatuses.includes(status);
     },
   },

--- a/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
@@ -1,63 +1,18 @@
 <template>
   <div class="legend">
-    <!-- Annotating -->
-    <div class="status" @click="toggleFilter('annotation')">
-      <font-awesome-icon icon="asterisk" size="lg" :style="{
-        color: isFiltered('annotation')
-          ? 'var(--rosalution-grey-300)'
-          : 'var(--rosalution-status-annotation)'
+    <div v-for="status in statuses" :key="status.name" class="status" @click="toggleFilter(status.name)">
+      <font-awesome-icon :icon="status.icon" size="lg" :style="{
+        color: isFiltered(status.name)
+          ? `var(--rosalution-status-${status.name})`
+          : 'var(--rosalution-grey-300)',
       }" />
-      <p :style="{ color: isFiltered('annotation') ? 'var(--rosalution-grey-300)' : '' }">Annotating</p>
-    </div>
-
-    <!-- Ready -->
-    <div class="status" @click="toggleFilter('ready')">
-      <font-awesome-icon icon="clipboard-check" size="lg" :style="{
-        color: isFiltered('ready')
-          ? 'var(--rosalution-grey-300)'
-          : 'var(--rosalution-status-ready)'
-      }" />
-      <p :style="{ color: isFiltered('ready') ? 'var(--rosalution-grey-300)' : '' }">Ready</p>
-    </div>
-
-    <!-- Active -->
-    <div class="status" @click="toggleFilter('active')">
-      <font-awesome-icon icon="book-open" size="lg" :style="{
-        color: isFiltered('active')
-          ? 'var(--rosalution-grey-300)'
-          : 'var(--rosalution-status-active)'
-      }" />
-      <p :style="{ color: isFiltered('active') ? 'var(--rosalution-grey-300)' : '' }">Active</p>
-    </div>
-
-    <!-- On Hold -->
-    <div class="status" @click="toggleFilter('on-hold')">
-      <font-awesome-icon icon="pause" size="lg" :style="{
-        color: isFiltered('on-hold')
-          ? 'var(--rosalution-grey-300)'
-          : 'var(--rosalution-status-on-hold)'
-      }" />
-      <p :style="{ color: isFiltered('on-hold') ? 'var(--rosalution-grey-300)' : '' }">On Hold</p>
-    </div>
-
-    <!-- Approved -->
-    <div class="status" @click="toggleFilter('approved')">
-      <font-awesome-icon icon="check" size="lg" :style="{
-        color: isFiltered('approved')
-          ? 'var(--rosalution-grey-300)'
-          : 'var(--rosalution-status-approved)'
-      }" />
-      <p :style="{ color: isFiltered('approved') ? 'var(--rosalution-grey-300)' : '' }">Approved</p>
-    </div>
-
-    <!-- Declined -->
-    <div class="status" @click="toggleFilter('declined')">
-      <font-awesome-icon icon="x" size="lg" :style="{
-        color: isFiltered('declined')
-          ? 'var(--rosalution-grey-300)'
-          : 'var(--rosalution-status-declined)'
-      }" />
-      <p :style="{ color: isFiltered('declined') ? 'var(--rosalution-grey-300)' : '' }">Declined</p>
+      <p :style="{
+        color: isFiltered(status.name)
+          ? ''
+          : 'var(--rosalution-grey-300)',
+      }">
+        {{ status.displayName }}
+      </p>
     </div>
   </div>
 </template>
@@ -73,23 +28,35 @@ export default {
   },
   data() {
     return {
-      filteredStatuses: [],
+      activeFilters: [],
+      statuses: [
+        {name: 'annotation', displayName: 'Annotating', icon: 'asterisk'},
+        {name: 'ready', displayName: 'Ready', icon: 'clipboard-check'},
+        {name: 'active', displayName: 'Active', icon: 'book-open'},
+        {name: 'on-hold', displayName: 'On Hold', icon: 'pause'},
+        {name: 'approved', displayName: 'Approved', icon: 'check'},
+        {name: 'declined', displayName: 'Declined', icon: 'times'},
+      ],
     };
   },
   methods: {
     toggleFilter(status) {
-      if (this.isFiltered(status)) {
-        const index = this.filteredStatuses.indexOf(status);
-        if (index !== -1) {
-          this.filteredStatuses.splice(index, 1);
-        }
+      const index = this.activeFilters.indexOf(status);
+
+      if (index !== -1) {
+        this.activeFilters.splice(index, 1);
       } else {
-        this.filteredStatuses.push(status);
+        this.activeFilters.push(status);
       }
-      this.$emit('filtered-statuses', this.filteredStatuses);
+
+      if (this.activeFilters.length === this.statuses.length) {
+        this.activeFilters = [];
+      }
+
+      this.$emit('filtered-statuses', this.activeFilters);
     },
     isFiltered(status) {
-      return this.filteredStatuses.includes(status);
+      return this.activeFilters.includes(status) || this.activeFilters.length === 0;
     },
   },
 };

--- a/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
@@ -22,7 +22,7 @@ import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
   name: 'analysis-listing-legend',
-  emits: ['filtered-statuses'],
+  emits: ['filtered-changed'],
   components: {
     'font-awesome-icon': FontAwesomeIcon,
   },
@@ -53,7 +53,7 @@ export default {
         this.activeFilters = [];
       }
 
-      this.$emit('filtered-statuses', this.activeFilters);
+      this.$emit('filtered-changed', this.activeFilters);
     },
     isFiltered(status) {
       return this.activeFilters.includes(status) || this.activeFilters.length === 0;

--- a/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisListingLegend.vue
@@ -1,44 +1,125 @@
 <template>
   <div class="legend">
-    <font-awesome-icon icon="asterisk" size="lg" style="color: var(--rosalution-status-annotation);"/>
-    <p>Annotating</p>
-    <font-awesome-icon icon="clipboard-check" size="lg" style="color: var(--rosalution-status-ready);"/>
-    <p>Ready</p>
-    <font-awesome-icon icon="book-open" size="lg" style="color: var(--rosalution-status-active)"/>
-    <p>Active</p>
-    <font-awesome-icon icon="pause" size="lg" style="color: var(--rosalution-status-on-hold)"/>
-    <p>On Hold</p>
-    <font-awesome-icon icon="check" size="lg" style="color: var(--rosalution-status-approved)"/>
-    <p>Approved</p>
-    <font-awesome-icon icon="x" size="lg" style="color: var(--rosalution-status-declined)"/>
-    <p>Declined</p>
+    <!-- Annotating -->
+    <div class="status" @click="toggleFilter('annotating')">
+      <font-awesome-icon icon="asterisk" size="lg" :style="{
+        color: isFiltered('annotating')
+          ? 'var(--rosalution-grey-300)'
+          : 'var(--rosalution-status-annotation)'
+      }" />
+      <p :style="{ color: isFiltered('annotating') ? 'var(--rosalution-grey-300)' : '' }">Annotating</p>
+    </div>
+
+    <!-- Ready -->
+    <div class="status" @click="toggleFilter('ready')">
+      <font-awesome-icon icon="clipboard-check" size="lg" :style="{
+        color: isFiltered('ready')
+          ? 'var(--rosalution-grey-300)'
+          : 'var(--rosalution-status-ready)'
+      }" />
+      <p :style="{ color: isFiltered('ready') ? 'var(--rosalution-grey-300)' : '' }">Ready</p>
+    </div>
+
+    <!-- Active -->
+    <div class="status" @click="toggleFilter('active')">
+      <font-awesome-icon icon="book-open" size="lg" :style="{
+        color: isFiltered('active')
+          ? 'var(--rosalution-grey-300)'
+          : 'var(--rosalution-status-active)'
+      }" />
+      <p :style="{ color: isFiltered('active') ? 'var(--rosalution-grey-300)' : '' }">Active</p>
+    </div>
+
+    <!-- On Hold -->
+    <div class="status" @click="toggleFilter('onHold')">
+      <font-awesome-icon icon="pause" size="lg" :style="{
+        color: isFiltered('onHold')
+          ? 'var(--rosalution-grey-300)'
+          : 'var(--rosalution-status-on-hold)'
+      }" />
+      <p :style="{ color: isFiltered('onHold') ? 'var(--rosalution-grey-300)' : '' }">On Hold</p>
+    </div>
+
+    <!-- Approved -->
+    <div class="status" @click="toggleFilter('approved')">
+      <font-awesome-icon icon="check" size="lg" :style="{
+        color: isFiltered('approved')
+          ? 'var(--rosalution-grey-300)'
+          : 'var(--rosalution-status-approved)'
+      }" />
+      <p :style="{ color: isFiltered('approved') ? 'var(--rosalution-grey-300)' : '' }">Approved</p>
+    </div>
+
+    <!-- Declined -->
+    <div class="status" @click="toggleFilter('declined')">
+      <font-awesome-icon icon="x" size="lg" :style="{
+        color: isFiltered('declined')
+          ? 'var(--rosalution-grey-300)'
+          : 'var(--rosalution-status-declined)'
+      }" />
+      <p :style="{ color: isFiltered('declined') ? 'var(--rosalution-grey-300)' : '' }">Declined</p>
+    </div>
   </div>
 </template>
 
-<style scoped>
+<script>
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
+export default {
+  name: 'analysis-listing-legend',
+  emits: ['filtered-statuses'],
+  components: {
+    'font-awesome-icon': FontAwesomeIcon,
+  },
+  data() {
+    return {
+      filteredStatuses: [],
+    };
+  },
+  methods: {
+    toggleFilter(status) {
+      if (this.isFiltered(status)) {
+        // If the status is already filtered, remove it from the array
+        const index = this.filteredStatuses.indexOf(status);
+        if (index !== -1) {
+          this.filteredStatuses.splice(index, 1);
+        }
+      } else {
+        // If the status is not filtered, add it to the array
+        this.filteredStatuses.push(status);
+      }
+      // Emit the filtered statuses
+      this.$emit('filtered-statuses', this.filteredStatuses);
+    },
+    isFiltered(status) {
+      // A status is filtered if it's in the array
+      return this.filteredStatuses.includes(status);
+    },
+  },
+};
+</script>
+
+<style scoped>
 .legend {
   display: flex;
   flex-grow: 0;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: var(--p-10);
   border-radius: var(--content-border-radius);
   padding: var(--p-8);
   background-color: var(--secondary-background-color);
 }
 
-.legend p {
-  line-height: .245rem;
-  padding-right: var(--p-10);
+.status {
+  display: flex;
+  align-items: center;
+  user-select: none;
 }
 
+.legend p {
+  line-height: .245rem;
+  padding-left: var(--p-10);
+}
 </style>
-
-
-<script>
-export default {
-  name: 'analysis-listing-legend',
-};
-</script>

--- a/frontend/src/views/AnalysisListingView.vue
+++ b/frontend/src/views/AnalysisListingView.vue
@@ -27,7 +27,7 @@
   <app-footer>
     <InputDialog data-test="phenotips-import-dialog"/>
     <NotificationDialog data-test="notification-dialog" />
-    <AnalysisListingLegend/>
+    <AnalysisListingLegend @filtered-statuses="updateFilter"/>
   </app-footer>
 </div>
 </template>
@@ -62,34 +62,44 @@ export default {
       store: authStore,
       searchText: '',
       analysisList: [],
+      filteredStatuses: [],
     };
   },
   computed: {
     username() {
       return this.store.state.username;
     },
+    filteredAnalysisListing() {
+      console.log(this.filteredStatuses)
+      return this.analysisList.filter(analysis => {
+        return !this.filteredStatuses.includes(analysis.latest_status);
+      });
+    },
     searchedAnalysisListing() {
       const lowerCaseSearchText = this.searchText.toLowerCase();
 
-      return this.searchText === '' ? this.analysisList : this.analysisList.filter( (analysis) => {
+      return this.searchText === '' ? this.filteredAnalysisListing : this.filteredAnalysisListing.filter(analysis => {
         return [analysis.name,
-          analysis.created_date,
-          analysis.last_modified_date,
-          analysis.nominated_by,
-        ].some((content) => content.toLowerCase().includes(lowerCaseSearchText)) ||
-          analysis.genomic_units.some((unit) => {
+        analysis.created_date,
+        analysis.last_modified_date,
+        analysis.nominated_by,
+        ].some(content => content.toLowerCase().includes(lowerCaseSearchText)) ||
+          analysis.genomic_units.some(unit => {
             return (unit.gene && unit.gene.toLowerCase().includes(lowerCaseSearchText)) ||
-                (unit.transcripts &&
-                    unit.transcripts.some((transcript) => transcript.toLowerCase().includes(lowerCaseSearchText))) ||
-                (unit.variants && unit.variants.some((variant) => variant.toLowerCase().includes(lowerCaseSearchText)));
+              (unit.transcripts &&
+                unit.transcripts.some(transcript => transcript.toLowerCase().includes(lowerCaseSearchText))) ||
+              (unit.variants && unit.variants.some(variant => variant.toLowerCase().includes(lowerCaseSearchText)));
           });
-      } );
+      });
     },
   },
   created() {
     this.getListing();
   },
   methods: {
+    updateFilter(filter) {
+      this.filteredStatuses = filter;
+    },
     async getListing() {
       this.analysisList.length = 0;
       const analyses = await Analyses.all();

--- a/frontend/src/views/AnalysisListingView.vue
+++ b/frontend/src/views/AnalysisListingView.vue
@@ -27,7 +27,7 @@
   <app-footer>
     <InputDialog data-test="phenotips-import-dialog"/>
     <NotificationDialog data-test="notification-dialog" />
-    <AnalysisListingLegend @filtered-statuses="updateFilter"/>
+    <AnalysisListingLegend @filtered-changed="filteredUpdated"/>
   </app-footer>
 </div>
 </template>
@@ -62,7 +62,7 @@ export default {
       store: authStore,
       searchText: '',
       analysisList: [],
-      filteredStatuses: [],
+      filteredChanged: [],
     };
   },
   computed: {
@@ -71,8 +71,8 @@ export default {
     },
     filteredAnalysisListing() {
       return this.analysisList.filter((analysis) => {
-        return this.filteredStatuses.length === 0 ||
-          this.filteredStatuses.includes(analysis.latest_status.toLowerCase());
+        return this.filteredChanged.length === 0 ||
+          this.filteredChanged.includes(analysis.latest_status.toLowerCase());
       });
     },
     searchedAnalysisListing() {
@@ -97,8 +97,8 @@ export default {
     this.getListing();
   },
   methods: {
-    updateFilter(filteredStatuses) {
-      this.filteredStatuses = filteredStatuses;
+    filteredUpdated(filteredChanged) {
+      this.filteredChanged = filteredChanged;
     },
     async getListing() {
       this.analysisList.length = 0;

--- a/frontend/src/views/AnalysisListingView.vue
+++ b/frontend/src/views/AnalysisListingView.vue
@@ -70,25 +70,25 @@ export default {
       return this.store.state.username;
     },
     filteredAnalysisListing() {
-      return this.analysisList.filter(analysis => {
-        return !this.filteredStatuses.includes(analysis.latest_status.toLowerCase());
-
+      return this.analysisList.filter((analysis) => {
+        return this.filteredStatuses.length === 0 ||
+          this.filteredStatuses.includes(analysis.latest_status.toLowerCase());
       });
     },
     searchedAnalysisListing() {
       const lowerCaseSearchText = this.searchText.toLowerCase();
 
-      return this.searchText === '' ? this.filteredAnalysisListing : this.filteredAnalysisListing.filter(analysis => {
+      return this.searchText === '' ? this.filteredAnalysisListing : this.filteredAnalysisListing.filter((analysis) => {
         return [analysis.name,
-        analysis.created_date,
-        analysis.last_modified_date,
-        analysis.nominated_by,
-        ].some(content => content.toLowerCase().includes(lowerCaseSearchText)) ||
-          analysis.genomic_units.some(unit => {
+          analysis.created_date,
+          analysis.last_modified_date,
+          analysis.nominated_by,
+        ].some((content) => content.toLowerCase().includes(lowerCaseSearchText)) ||
+          analysis.genomic_units.some((unit) => {
             return (unit.gene && unit.gene.toLowerCase().includes(lowerCaseSearchText)) ||
               (unit.transcripts &&
-                unit.transcripts.some(transcript => transcript.toLowerCase().includes(lowerCaseSearchText))) ||
-              (unit.variants && unit.variants.some(variant => variant.toLowerCase().includes(lowerCaseSearchText)));
+                unit.transcripts.some((transcript) => transcript.toLowerCase().includes(lowerCaseSearchText))) ||
+              (unit.variants && unit.variants.some((variant) => variant.toLowerCase().includes(lowerCaseSearchText)));
           });
       });
     },
@@ -97,8 +97,8 @@ export default {
     this.getListing();
   },
   methods: {
-    updateFilter(filter) {
-      this.filteredStatuses = filter;
+    updateFilter(filteredStatuses) {
+      this.filteredStatuses = filteredStatuses;
     },
     async getListing() {
       this.analysisList.length = 0;

--- a/frontend/src/views/AnalysisListingView.vue
+++ b/frontend/src/views/AnalysisListingView.vue
@@ -70,9 +70,9 @@ export default {
       return this.store.state.username;
     },
     filteredAnalysisListing() {
-      console.log(this.filteredStatuses)
       return this.analysisList.filter(analysis => {
-        return !this.filteredStatuses.includes(analysis.latest_status);
+        return !this.filteredStatuses.includes(analysis.latest_status.toLowerCase());
+
       });
     },
     searchedAnalysisListing() {

--- a/frontend/test/components/AnalysisListing/AnalysisListingLegend.spec.js
+++ b/frontend/test/components/AnalysisListing/AnalysisListingLegend.spec.js
@@ -5,13 +5,23 @@ import AnalysisListingLegend from '@/components/AnalysisListing/AnalysisListingL
 
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
+const statuses = [
+  {name: 'annotation', displayName: 'Annotating', icon: 'asterisk'},
+  {name: 'ready', displayName: 'Ready', icon: 'clipboard-check'},
+  {name: 'active', displayName: 'Active', icon: 'book-open'},
+  {name: 'on-hold', displayName: 'On Hold', icon: 'pause'},
+  {name: 'approved', displayName: 'Approved', icon: 'check'},
+  {name: 'declined', displayName: 'Declined', icon: 'times'},
+];
+
 /**
- * helper function that shadllow mounts and returns the rendered component
+ * helper function that shallow mounts and returns the rendered component
  * @param {props} props props for testing to overwrite default props
  * @return {VueWrapper} returns a shallow mounted using props
  */
 function getMountedComponent(props) {
   const defaultProps = {
+    statuses,
   };
 
   return shallowMount(AnalysisListingLegend, {
@@ -29,5 +39,56 @@ describe('AnalysisListingLegend.vue', () => {
     const wrapper = getMountedComponent();
     expect(wrapper.html()).to.contains('Ready');
     expect(wrapper.html()).to.contains('Active');
+  });
+
+  it('should all be colored when no statuses are being filtered for', () => {
+    const wrapper = getMountedComponent();
+    statuses.forEach((status) => {
+      expect(wrapper.html()).to.contains(`color: var(--rosalution-status-${status.name})`);
+    });
+  });
+
+  it('should only color the filtered status', async () => {
+    const wrapper = getMountedComponent();
+    const statusElements = wrapper.findAll('.status');
+    let readyStatus;
+
+    for (let i = 0; i < statusElements.length; i++) {
+      if (statusElements.at(i).text() === 'Ready') {
+        readyStatus = statusElements.at(i);
+      }
+    }
+
+    if (readyStatus) {
+      await readyStatus.trigger('click');
+      expect(wrapper.html()).to.contains('color: var(--rosalution-status-ready)');
+      statuses.forEach((status) => {
+        if (status.name !== 'ready') {
+          expect(wrapper.html()).to.contains(`color: var(--rosalution-grey-300)`);
+        }
+      });
+    } else {
+      throw new Error('Ready status not found');
+    }
+  });
+
+  it('should emit a filtered-statuses event when a status is clicked', async () => {
+    const wrapper = getMountedComponent();
+    const statusElements = wrapper.findAll('.status');
+    let readyStatus;
+
+    for (let i = 0; i < statusElements.length; i++) {
+      if (statusElements.at(i).text() === 'Ready') {
+        readyStatus = statusElements.at(i);
+      }
+    }
+
+    if (readyStatus) {
+      await readyStatus.trigger('click');
+      expect(wrapper.emitted()).to.have.property('filtered-statuses');
+      expect(wrapper.emitted()['filtered-statuses'][0][0]).to.contains('ready');
+    } else {
+      throw new Error('Ready status not found');
+    }
   });
 });

--- a/frontend/test/components/AnalysisListing/AnalysisListingLegend.spec.js
+++ b/frontend/test/components/AnalysisListing/AnalysisListingLegend.spec.js
@@ -72,7 +72,7 @@ describe('AnalysisListingLegend.vue', () => {
     }
   });
 
-  it('should emit a filtered-statuses event when a status is clicked', async () => {
+  it('should emit a filtered-changed event when a status is clicked', async () => {
     const wrapper = getMountedComponent();
     const statusElements = wrapper.findAll('.status');
     let readyStatus;
@@ -85,8 +85,8 @@ describe('AnalysisListingLegend.vue', () => {
 
     if (readyStatus) {
       await readyStatus.trigger('click');
-      expect(wrapper.emitted()).to.have.property('filtered-statuses');
-      expect(wrapper.emitted()['filtered-statuses'][0][0]).to.contains('ready');
+      expect(wrapper.emitted()).to.have.property('filtered-changed');
+      expect(wrapper.emitted()['filtered-changed'][0][0]).to.contains('ready');
     } else {
       throw new Error('Ready status not found');
     }

--- a/frontend/test/components/AnalysisListing/AnalysisListingLegend.spec.js
+++ b/frontend/test/components/AnalysisListing/AnalysisListingLegend.spec.js
@@ -54,8 +54,8 @@ describe('AnalysisListingLegend.vue', () => {
     let readyStatus;
 
     for (let i = 0; i < statusElements.length; i++) {
-      if (statusElements.at(i).text() === 'Ready') {
-        readyStatus = statusElements.at(i);
+      if (statusElements[i].text() === 'Ready') {
+        readyStatus = statusElements[i];
       }
     }
 
@@ -78,8 +78,8 @@ describe('AnalysisListingLegend.vue', () => {
     let readyStatus;
 
     for (let i = 0; i < statusElements.length; i++) {
-      if (statusElements.at(i).text() === 'Ready') {
-        readyStatus = statusElements.at(i);
+      if (statusElements[i].text() === 'Ready') {
+        readyStatus = statusElements[i];
       }
     }
 

--- a/frontend/test/views/AnalysisListingView.spec.js
+++ b/frontend/test/views/AnalysisListingView.spec.js
@@ -7,6 +7,7 @@ import Analyses from '@/models/analyses.js';
 import AnalysisCard from '@/components/AnalysisListing/AnalysisCard.vue';
 import AnalysisCreateCard from '@/components/AnalysisListing/AnalysisCreateCard.vue';
 import AnalysisListingHeader from '@/components/AnalysisListing/AnalysisListingHeader.vue';
+import AnalysisListingLegend from '@/components/AnalysisListing/AnalysisListingLegend.vue';
 import AnalysisListingView from '@/views/AnalysisListingView.vue';
 
 import NotificationDialog from '@/components/Dialogs/NotificationDialog.vue';
@@ -134,6 +135,14 @@ describe('AnalysisListingView', () => {
     await header.vm.$nextTick();
 
     expect(wrapper.vm.$router.push.called).to.be.true;
+  });
+
+  it('should update the filter when the analysis listing header emits the update event', async () => {
+    const legend = wrapper.findComponent(AnalysisListingLegend);
+    legend.vm.$emit('filtered-statuses', ['Approved']);
+    await legend.vm.$nextTick();
+
+    expect(wrapper.vm.filteredStatuses).to.contain('Approved');
   });
 });
 

--- a/frontend/test/views/AnalysisListingView.spec.js
+++ b/frontend/test/views/AnalysisListingView.spec.js
@@ -139,10 +139,10 @@ describe('AnalysisListingView', () => {
 
   it('should update the filter when the analysis listing header emits the update event', async () => {
     const legend = wrapper.findComponent(AnalysisListingLegend);
-    legend.vm.$emit('filtered-statuses', ['Approved']);
+    legend.vm.$emit('filtered-changed', ['Approved']);
     await legend.vm.$nextTick();
 
-    expect(wrapper.vm.filteredStatuses).to.contain('Approved');
+    expect(wrapper.vm.filteredChanged).to.contain('Approved');
   });
 });
 

--- a/system-tests/e2e/status_filter_case_cards.cy.js
+++ b/system-tests/e2e/status_filter_case_cards.cy.js
@@ -1,0 +1,63 @@
+describe('status_filter_case_cards.cy.js', () => {
+  before(() => {
+    cy.resetDatabase();
+  });
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('filters cases by status', () => {
+    cy.get('.analysis-card').should('have.length', 6);
+    cy.get('.legend > :nth-child(1)').click();
+    cy.get('.analysis-card').should('have.length', 1);
+    cy.get('.case-name').should('contain', 'CPAM0084');
+    cy.get('.legend > :nth-child(1)').click();
+    cy.get('.legend > :nth-child(2)').click();
+    cy.get('.analysis-card').should('have.length', 1);
+    cy.get('.case-name').should('contain', 'CPAM0053');
+    cy.get('.legend > :nth-child(2)').click();
+    cy.get('.legend > :nth-child(3)').click();
+    cy.get('.analysis-card').should('have.length', 0);
+    cy.get('.legend > :nth-child(3)').click();
+    cy.get('.legend > :nth-child(4)').click();
+    cy.get('.analysis-card').should('have.length', 0);
+    cy.get('.legend > :nth-child(4)').click();
+    cy.get('.legend > :nth-child(5)').click();
+    cy.get('.analysis-card').should('have.length', 2);
+    cy.get('.analysis-card > .analysis-base').should('contain', 'CPAM0002');
+    cy.get('.analysis-card > .analysis-base').should('contain', 'CPAM0046');
+    cy.get('.legend > :nth-child(5)').click();
+    cy.get('.legend > :nth-child(6)').click();
+    cy.get('.analysis-card').should('have.length', 2);
+    cy.get('.analysis-card > .analysis-base').should('contain', 'CPAM0047');
+    cy.get('.analysis-card > .analysis-base').should('contain', 'CPAM0065');
+    cy.get('.legend > :nth-child(6)').click();
+  });
+
+  it('filters cases by multiple statuses', () => {
+    cy.get('.analysis-card').should('have.length', 6);
+    cy.get('.legend > :nth-child(1)').click();
+    cy.get('.legend > :nth-child(2)').click();
+    cy.get('.analysis-card').should('have.length', 2);
+    cy.get('.analysis-card > .analysis-base').should('contain', 'CPAM0053');
+    cy.get('.analysis-card > .analysis-base').should('contain', 'CPAM0084');
+  });
+
+  it('resets the filters if all are selected', () => {
+    cy.get('.analysis-card').should('have.length', 6);
+    cy.get('.legend > :nth-child(1)').click();
+    cy.get('.analysis-card').should('have.length', 1);
+    cy.get('.legend > :nth-child(2)').click();
+    cy.get('.analysis-card').should('have.length', 2);
+    cy.get('.legend > :nth-child(3)').click();
+    cy.get('.analysis-card').should('have.length', 2);
+    cy.get('.legend > :nth-child(4)').click();
+    cy.get('.analysis-card').should('have.length', 2);
+    cy.get('.legend > :nth-child(5)').click();
+    cy.get('.analysis-card').should('have.length', 4);
+    cy.get('.legend > :nth-child(6)').click();
+    cy.get('.analysis-card').should('have.length', 6);
+    cy.get('.legend > :nth-child(2)').click();
+    cy.get('.analysis-card').should('have.length', 1);
+  });
+});


### PR DESCRIPTION

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.


## Pull Request Details

Wrike Task- [As an authorized user, I want to filter by status rollup so that I can quickly find cases within the application based on this criteria.](https://www.wrike.com/open.htm?id=1079629899)

Changes made:

- Made the statuses in the legend clickable
  - when clicking on a status, it will filter all other cases out that do not have that status
  - added CSS properties to indicate the active or inactive state of that status
-Added tests for this feature 

**To Review:**

- [x] Static Analysis by Reviewer
- [x] Observe changes made
  1.   Deploy Rosalution
  ``` bash
  # From the root of rosalution
  docker-compose down
  docker system prune -a --volumes
  docker-compose up --build -d
  ``` 
  2. Go to: [http://local.rosalution.cgds/rosalution/](http://local.rosalution.cgds/rosalution/)
  3. Login with a user
    - username: developer
  4. click on a status in the legend to filter out all other statuses.
    - ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/1f5a7d11-710c-4f55-b9c3-bad14cf0455d)
  5. click on the same status to return to the unfiltered state.
    - ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/698c6b18-3fa8-464c-8b8f-9076db7deb52)
  6. click on any combination of statuses in the legend to see only those in the filtered results
    - ![image](https://github.com/uab-cgds-worthey/rosalution/assets/4248757/11284f06-74e3-4369-96d8-896f39c511c8)
  7. You can enable multiple and disable them in any order to reset back to fully unfiltered.
  8. If you begin to filter and turn all statuses back on manually, it will reset back to the default state and function as if no filter was enabled.

 
- [x] All Github Actions checks have passed.
