### PR TITLE
Image assets in production with broken links

### DIFF
--- a/frontend/src/components/AnalysisListing/AnalysisCard.vue
+++ b/frontend/src/components/AnalysisListing/AnalysisCard.vue
@@ -139,9 +139,9 @@ export default {
     getLogoSrc(type) {
       switch (type) {
         case 'monday_com':
-          return '/src/assets/monday-avatar-logo.svg';
+          return new URL('/src/assets/monday-avatar-logo.svg', import.meta.url);
         case 'phenotips_com':
-          return '/src/assets/phenotips-favicon-96x96.png';
+          return new URL('/src/assets/phenotips-favicon-96x96.png', import.meta.url);
         default:
           return '';
       }

--- a/frontend/src/components/RosalutionHeader.vue
+++ b/frontend/src/components/RosalutionHeader.vue
@@ -138,9 +138,9 @@ export default {
   methods: {
     getIconSrc(linkType) {
       if (linkType === 'monday_com') {
-        return '/src/assets/monday-avatar-logo.svg';
+        return new URL('/src/assets/monday-avatar-logo.svg', import.meta.url);
       } else if (linkType === 'phenotips_com') {
-        return '/src/assets/phenotips-favicon-96x96.png';
+        return new URL('/src/assets/phenotips-favicon-96x96.png', import.meta.url);
       }
     },
     getIconClass(linkType) {

--- a/frontend/src/components/SectionImage.vue
+++ b/frontend/src/components/SectionImage.vue
@@ -48,7 +48,7 @@ export default {
   },
   data() {
     return {
-      imageSrc: '/src/assets/rosalution-logo.svg',
+      imageSrc: new URL('/src/assets/rosalution-logo.svg', import.meta.url),
     };
   },
   created() {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

Wrike Ticket - [Monday.com, Phenotips, and Rosalution temporary Icons are broken on Production (BUG)](https://www.wrike.com/open.htm?id=1183837287)

Changes made:

- @JmScherer Fixed the assets for the 3rd party link attachments and the temporary loading image from being broken links

**To Review:**

- [x] Static Analysis by Reviewer
- [ ] The changes made to the analysis card and temporary image icon are working as intended/rendered correctly.
  It is very important to note ** must run branch __resolve-assets-missing-from-production-local-test-branch__ because the changes to disable packaging and stripping loggin has to be temporarily removed so that we can login locally for production **

  To check this run the following commands:
    ``` bash
    # From the root of Rosalution
    git checkout resolve-assets-missing-from-production-local-test-branch
    docker compose down
    docker system prune -a --volumes

    docker-compose -f docker-compose.local-production.yml up --build
    ```
  - Go to [local.rosalution.cgds/rosalution](local.rosalution.cgds/rosalution)
  - Login with `vrr-prep` user
  - Go to any case and attach a monday.com or phenotips URLs to a case
    - Check if the analysis page shows icon
    - Check if home page shows icon
      ![image](https://github.com/uab-cgds-worthey/rosalution/assets/1209059/ec83e0d6-6940-4a33-9ea2-8b13e43dab81)
      ![image](https://github.com/uab-cgds-worthey/rosalution/assets/1209059/0310446e-005d-4a47-936f-48a046fadf65)
  - Upload a reallllly large image
    - ![image](https://github.com/uab-cgds-worthey/rosalution/assets/1209059/fe645521-4aff-4f89-b055-faf612ee0ea0)

- [x] All Github Actions checks have passed.
