### PR TITLE
Opening images in new tab for the short term

### DIFF
--- a/frontend/src/components/SectionImage.vue
+++ b/frontend/src/components/SectionImage.vue
@@ -1,11 +1,13 @@
 <template>
     <div class="image-row">
-      <a :href="domId">
+      <router-link :to="{
+        name: 'file',
+        params: {
+          file_id: imageId,
+        },
+      }" target="_blank" rel="noreferrer noopener">
         <img class="section-image" :src="imageSrc" data-test="annotation-image" :id="imageId"/>
-      </a>
-      <a href="#_" class="lightbox" :id="imageId">
-        <span :style="{backgroundImage: `url(${this.imageSrc})`}"></span>
-      </a>
+      </router-link>
       <!-- TODO: Since both AnalysisView and AnnotationView are using this component,
         change the emit to be update-image -->
         <button v-if="this.writePermissions"
@@ -39,11 +41,6 @@ export default {
     writePermissions: {
       type: Boolean,
       default: false,
-    },
-  },
-  computed: {
-    domId() {
-      return `#${this.imageId}`;
     },
   },
   data() {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,7 @@ import App from './App.vue';
 import LoginView from './views/LoginView.vue';
 import LogoutView from './views/LogoutView.vue';
 import AnalysisListingView from './views/AnalysisListingView.vue';
+import FileView from './views/FileView.vue';
 import NotFoundView from './views/NotFound.vue';
 import AccountView from './views/AccountView.vue';
 import AnalysisView from './views/AnalysisView.vue';
@@ -44,6 +45,7 @@ const routes = [
   {path: '/rosalution', component: AnalysisListingView},
   {path: '/rosalution/account', name: 'account', component: AccountView},
   {path: '/rosalution/analysis/:analysis_name', name: 'analysis', component: AnalysisView, props: true},
+  {path: '/rosalution/analysis/file/:file_id', name: 'file', component: FileView, props: true},
   {path: '/rosalution/analysis/:analysis_name/annotation/', name: 'annotation', component: AnnotationView, props: true},
   {path: '/rosalution/logout', name: 'logout', component: LogoutView},
   {path: '/:pathMatch(.*)', component: NotFoundView},

--- a/frontend/src/views/FileView.vue
+++ b/frontend/src/views/FileView.vue
@@ -1,0 +1,52 @@
+<template>
+  <app-header>
+  <RosalutionHeader
+    :username="auth.getUsername()"
+  >
+  <div></div>
+  </RosalutionHeader>
+</app-header>
+<app-content>
+  <img :src="imageSrc" :data-test="`rosalution-file-${this.file_id}`"/>
+</app-content>
+</template>
+
+<script>
+import RosalutionHeader from '@/components/RosalutionHeader.vue';
+
+import {authStore} from '@/stores/authStore.js';
+import FileRequests from '@/fileRequests.js';
+
+export default {
+  name: 'file-view',
+  components: {
+    RosalutionHeader,
+  },
+  props: ['file_id'],
+  data: function() {
+    return {
+      auth: authStore,
+      imageSrc: new URL('/src/assets/rosalution-logo.svg', import.meta.url),
+    };
+  },
+  created() {
+    this.sectionImageUpdate();
+  },
+  methods: {
+    async sectionImageUpdate() {
+      const loadingImage = await FileRequests.getImage(this.file_id);
+      this.imageSrc = loadingImage;
+    },
+  },
+};
+</script>
+
+<style scoped>
+  div {
+    flex: 1 1 auto;
+  }
+
+  img {
+    margin: var(--p-10);
+  }
+</style>

--- a/system-tests/e2e/attach_analysis_section_image.cy.js
+++ b/system-tests/e2e/attach_analysis_section_image.cy.js
@@ -1,6 +1,8 @@
 describe('attach analysis section images', () => {
   beforeEach(() => {
     cy.resetDatabase();
+    cy.fixture('section-image-1.jpg', {encoding: null}).as('sectionImage1');
+    cy.fixture('section-image-2.png', {encoding: null}).as('sectionImage2');
     cy.login('vrr-prep');
     cy.visit('/');
     cy.get('[href="/rosalution/analysis/CPAM0002"]').click();
@@ -9,7 +11,7 @@ describe('attach analysis section images', () => {
   it('should attach a jpg pedigree image', () => {
     cy.get('[href="#Pedigree"]').click();
     cy.get('[data-test="attach-logo-Pedigree"]').click({force: true});
-    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+    cy.get('.drop-file-box-content').selectFile('@sectionImage1', {
       action: 'drag-drop',
     });
     cy.get('[data-test="confirm"]').click();
@@ -20,7 +22,7 @@ describe('attach analysis section images', () => {
   it('should attach a png pedigree image', () => {
     cy.get('[href="#Pedigree"]').click();
     cy.get('[data-test="attach-logo-Pedigree"]').click({force: true});
-    cy.get('.drop-file-box-content').selectFile('../frontend/src/assets/gnomad-logo.png', {
+    cy.get('.drop-file-box-content').selectFile('@sectionImage2', {
       action: 'drag-drop',
     });
     cy.get('[data-test="confirm"]').click();
@@ -32,7 +34,7 @@ describe('attach analysis section images', () => {
     // First image - jpg
     cy.get('[href="#Pedigree"]').click();
     cy.get('[data-test="attach-logo-Pedigree"]').click({force: true});
-    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+    cy.get('.drop-file-box-content').selectFile('@sectionImage1', {
       action: 'drag-drop',
     });
     cy.get('[data-test="confirm"]').click();
@@ -40,7 +42,7 @@ describe('attach analysis section images', () => {
     // Second image - png
     cy.get('[href="#Pedigree"]').click();
     cy.get('[data-test="attach-logo-Pedigree"]').click({force: true});
-    cy.get('.drop-file-box-content').selectFile('../frontend/src/assets/gnomad-logo.png', {
+    cy.get('.drop-file-box-content').selectFile('@sectionImage2', {
       action: 'drag-drop',
     });
     cy.get('[data-test="confirm"]').click();
@@ -51,27 +53,26 @@ describe('attach analysis section images', () => {
   it('should attach an image and then updates the image to another image ', () => {
     cy.get('[href="#Pedigree"]').click();
     cy.get('[data-test="attach-logo-Pedigree"]').click({force: true});
-    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+    cy.get('.drop-file-box-content').selectFile('@sectionImage1', {
       action: 'drag-drop',
     });
     cy.get('[data-test="confirm"]').click();
 
-    cy.get('[field="Pedigree"] > .image-row > .lightbox').invoke('attr', 'id').then((old_file_id) => {
-
+    cy.get('[field="Pedigree"] > .image-row > a').invoke('attr', 'href').then((oldFileUrl) => {
       cy.get('[data-test=annotation-edit-icon]').click({force: true});
-      cy.get('.drop-file-box-content').selectFile('../frontend/src/assets/gnomad-logo.png', {
+      cy.get('.drop-file-box-content').selectFile('@sectionImage2', {
         action: 'drag-drop',
       });
       cy.get('[data-test="confirm"]').click();
-  
-      cy.get('[field="Pedigree"] > .image-row > .lightbox').invoke('attr', 'id').should('not.contain', old_file_id)
+
+      cy.get('[field="Pedigree"] > .image-row > a').invoke('attr', 'href').should('not.contain', oldFileUrl);
     });
   });
 
   it('should upload an image to Pedigree and then remove the image', () => {
     cy.get('[href="#Pedigree"]').click();
     cy.get('[data-test="attach-logo-Pedigree"]').click({force: true});
-    cy.get('.drop-file-box-content').selectFile('../backend/tests/fixtures/pedigree-fake.jpg', {
+    cy.get('.drop-file-box-content').selectFile('@sectionImage1', {
       action: 'drag-drop',
     });
     cy.get('[data-test="confirm"]').click();
@@ -82,5 +83,4 @@ describe('attach analysis section images', () => {
 
     cy.get('[field="Pedigree"] > .image-row').should('not.exist');
   });
-
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.

## Pull Request Details

Wrike Ticket - [Investigate how to improve the images and how we expect them to work in the application](https://www.wrike.com/open.htm?id=1184833307)

Changes made:

- Removed the 'in focus' lightbox effectively and opens the image in a new 'file view' with it at full resolution

**To Review:**

- [x] Static Analysis by Reviewer
- [x] The changes made to opening images are working as intended/rendered correctly.
  To check this run the following commands:

  ``` bash
  # From the root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker compose up --build -d
  ```
    - Go to http://local.rosalution.cgds/rosalution/
    - Login with `vrr-prep` user
    - Upload images on analysis and annotation sections
    - Images on left click or "right click and open in new window" allow it to open more naturally?

- [x] All Github Actions checks have passed.
