### PR TITLE
Removed check for duplicate file name being blocked from uploaded as …

### DIFF
--- a/backend/src/routers/analysis_router.py
+++ b/backend/src/routers/analysis_router.py
@@ -213,8 +213,6 @@ def attach_supporting_evidence_file(
     analysis_name: str, upload_file: UploadFile = File(...), comments: str = Form(...), repositories=Depends(database)
 ):
     """Uploads a file to GridFS and adds it to the analysis"""
-    if bool(repositories["analysis"].find_file_by_name(analysis_name, upload_file.filename)):
-        raise HTTPException(status_code=409, detail="File with the same name already exists in the given analysis")
 
     new_file_object_id = repositories['bucket'].save_file(
         upload_file.file, upload_file.filename, upload_file.content_type

--- a/system-tests/e2e/case_supporting_evidence.cy.js
+++ b/system-tests/e2e/case_supporting_evidence.cy.js
@@ -151,7 +151,7 @@ describe('case_supporting_evidence.cy.js', () => {
     cy.get('.attachment-list').should('have.length', 0);
   });
 
-  it('should fail to attach the same supporting evidence file twice to the same analysis', () => {
+  it('should be able to attach the same supporting evidence file twice to the same analysis', () => {
     cy.get('#Supporting_Evidence').should('exist');
     cy.get('.attachment-list').should('have.length', 0);
     cy.get('[data-test="add-button"]').click();
@@ -172,7 +172,7 @@ describe('case_supporting_evidence.cy.js', () => {
     });
     cy.get('.comments').type('this is a test comment for a test file');
     cy.get('[data-test="confirm"]').click();
-    cy.get('.attachment-list').should('have.length', 1);
+    cy.get('.attachment-list').should('have.length', 2);
   });
 
   it('should be able to attach the same supporting evidence file to different analyses', () => {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

[https://www.wrike.com/open.htm?id=1187835232](https://www.wrike.com/open.htm?id=1187835232)

Changes made:

- Allows adding more than one file of the same name to supporting evidence in an analysis

**To Review:**

- [ ] Static Analysis by Reviewer
- [ ] Can a user upload two files of the same name to an analysis' supporting evidence
  ``` bash
  # from the root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker compose up --build
  ```
  - Navigate to [local.rosalution.cgds/rosalution](local.rosalution.cgds/rosalution)
  - Login as `vrr-prep`
  - Select an analysis
  - Upload the same file twice to supporting evidence
- [ ] All Github Actions checks have passed.

![Screenshot 2023-08-22 at 4 21 32 PM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/d7f4f0b1-79f6-4ac6-a334-2ba439e1abcf)