### PR TITLE
Make sure Rosalution is properly ignoring the self signed certificates generated by mkcert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,5 @@ media/
 *.crossref
 
 # SSL/TLS Certificates
-.certificates/
+**/.certificates/**
 *.pem

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,5 @@ media/
 *.crossref
 
 # SSL/TLS Certificates
+.certificates/
 *.pem


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.

## Pull Request Details

Changes made:

- Updated the .gitignore to include the `./etc/.certificates` folder

**To Review:**

- [x] Static Analysis by Reviewer
- [x] Does Rosalution still work as intended?
  To check this run the following commands:
  ``` bash
  # From the root of Rosalution
  docker compose down
  docker system prune -a --volumes
  
  ./setup.sh clean
  
  docker compose up --build
  ```
  - Go to `local.rosalution.cgds/rosalution` does it give a security error?
- [x] Are the `./etc/.certificates` certificate files not included in git?
  - Look at `git status` is anything changed? It should NOT include the .pem files
- [ ] All Github Actions checks have passed.

**The .pem files are grey in your vscode indicating that they are not included in git commits**
![Screenshot 2023-11-20 at 12 48 20 PM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/6064479e-815f-4117-9049-b7a36e4c57a6)
