### PR TITLE
[Frontend] Clicking the "New Discussion" button opens a field below the header line divider to enter an opinion

### DIFF
--- a/frontend/src/components/AnalysisView/DiscussionSection.vue
+++ b/frontend/src/components/AnalysisView/DiscussionSection.vue
@@ -4,8 +4,12 @@
         <div class="rosalution-section-header">
             <h2 class="rosalution-section-header-text">Discussion</h2>
             <span class="rosalution-section-center" data-test="header-datasets"/>
-            <button class="primary-button discussion-new-button" @click="this.newDiscussionPostForm">
-                New Discussion
+            <button
+                class="primary-button discussion-new-button"
+                @click="this.newDiscussionPostForm"
+                data-test="new-discussion-button"
+            >
+                    New Discussion
             </button>
             <label class="collapsable-icon" for="discussion_toggle">
                 <font-awesome-icon icon="chevron-down" size="lg"/>
@@ -21,10 +25,19 @@
                     data-test="new-discussion-input"
                 />
                 <div class="discussion-actions">
-                    <button class="secondary-button" @click="cancelNewDiscussionPost" data-test="new-discussion-cancel">
+                    <button
+                        class="secondary-button"
+                        @click="cancelNewDiscussionPost"
+                        data-test="new-discussion-cancel"
+                    >
                         Cancel
                     </button>
-                    <button class="primary-button" @click="newDiscussionPost" data-test="new-discussion-publish">
+                    <button
+                        class="primary-button publish-button"
+                        @click="newDiscussionPost"
+                        data-test="new-discussion-publish"
+                        :disabled="this.checkPostContent"
+                    >
                         Publish
                     </button>
                 </div>
@@ -66,32 +79,28 @@ export default {
   data: function() {
     return {
       newPostContent: '',
-      showNewPost: false
+      showNewPost: false,
     };
+  },
+  computed: {
+    checkPostContent() {
+      return this.newPostContent == '';
+    },
   },
   methods: {
     newDiscussionPostForm() {
-        this.showNewPost = true;
+      this.showNewPost = true;
     },
-    newDiscussionPost() {
-        this.$emit('discussion:new-post', this.newPostContent);
-        this.clearNewDiscussionField();
-    },
-    cancelNewDiscussionPost() {
-        this.clearNewDiscussionField();
-    },
-    clearNewDiscussionField() {
-        this.newPostContent = '';
-        this.showNewPost = false;
-    }
-  },
-  methods: {
     newDiscussionPost() {
       this.$emit('discussion:new-post', this.newPostContent);
+      this.clearNewDiscussionField();
     },
     cancelNewDiscussionPost() {
-      // Currently does nothing, will need to update to turn off the new post text
-      console.log('Cancelled post');
+      this.clearNewDiscussionField();
+    },
+    clearNewDiscussionField() {
+      this.newPostContent = '';
+      this.showNewPost = false;
     },
   },
 };
@@ -131,6 +140,10 @@ export default {
     display: flex;
     justify-content: right;
     margin-right: var(--p-16);
+}
+
+.publish-button {
+    margin-left: var(--p-8);
 }
 
 .collapsable-icon {

--- a/frontend/src/components/AnalysisView/DiscussionSection.vue
+++ b/frontend/src/components/AnalysisView/DiscussionSection.vue
@@ -140,6 +140,7 @@ export default {
     display: flex;
     justify-content: right;
     margin-right: var(--p-16);
+    margin-bottom: var(--p-10);
 }
 
 .publish-button {

--- a/frontend/src/components/AnalysisView/DiscussionSection.vue
+++ b/frontend/src/components/AnalysisView/DiscussionSection.vue
@@ -77,11 +77,11 @@ export default {
   },
   methods: {
     newDiscussionPost() {
-        console.log("Publishing Post!")
+        this.$emit('discussion:new-post', this.newPostContent)
     },
     cancelNewDiscussionPost() {
         console.log("Cancelled post");
-    }
+    },
   }
 };
 

--- a/frontend/src/components/AnalysisView/DiscussionSection.vue
+++ b/frontend/src/components/AnalysisView/DiscussionSection.vue
@@ -75,6 +75,14 @@ export default {
       console.log('Cancelled post');
     },
   },
+  methods: {
+    newDiscussionPost() {
+        console.log("Publishing Post!")
+    },
+    cancelNewDiscussionPost() {
+        console.log("Cancelled post");
+    }
+  }
 };
 
 </script>

--- a/frontend/src/components/AnalysisView/DiscussionSection.vue
+++ b/frontend/src/components/AnalysisView/DiscussionSection.vue
@@ -4,14 +4,16 @@
         <div class="rosalution-section-header">
             <h2 class="rosalution-section-header-text">Discussion</h2>
             <span class="rosalution-section-center" data-test="header-datasets"/>
-            <button class="primary-button discussion-new-button" @click="this.newDiscussionPost">New Discussion</button>
+            <button class="primary-button discussion-new-button" @click="this.newDiscussionPostForm">
+                New Discussion
+            </button>
             <label class="collapsable-icon" for="discussion_toggle">
                 <font-awesome-icon icon="chevron-down" size="lg"/>
             </label>
         </div>
         <div class="rosalution-section-seperator"></div>
         <div class="section-content">
-            <div class="discussion-new-post">
+            <div v-if="this.showNewPost" class="discussion-new-post">
                 <textarea
                     contenteditable="plaintext-only"
                     class="discussion-new-post-text-area"
@@ -64,16 +66,24 @@ export default {
   data: function() {
     return {
       newPostContent: '',
+      showNewPost: false
     };
   },
   methods: {
+    newDiscussionPostForm() {
+        this.showNewPost = true;
+    },
     newDiscussionPost() {
-      this.$emit('discussion:new-post', this.newPostContent);
+        this.$emit('discussion:new-post', this.newPostContent);
+        this.clearNewDiscussionField();
     },
     cancelNewDiscussionPost() {
-      // Currently does nothing, will need to update to turn off the new post text
-      console.log('Cancelled post');
+        this.clearNewDiscussionField();
     },
+    clearNewDiscussionField() {
+        this.newPostContent = '';
+        this.showNewPost = false;
+    }
   },
   methods: {
     newDiscussionPost() {

--- a/frontend/src/components/AnalysisView/DiscussionSection.vue
+++ b/frontend/src/components/AnalysisView/DiscussionSection.vue
@@ -77,12 +77,13 @@ export default {
   },
   methods: {
     newDiscussionPost() {
-        this.$emit('discussion:new-post', this.newPostContent)
+      this.$emit('discussion:new-post', this.newPostContent);
     },
     cancelNewDiscussionPost() {
-        console.log("Cancelled post");
+      // Currently does nothing, will need to update to turn off the new post text
+      console.log('Cancelled post');
     },
-  }
+  },
 };
 
 </script>

--- a/frontend/src/styles/rosalution.css
+++ b/frontend/src/styles/rosalution.css
@@ -24,6 +24,10 @@ html {
   cursor: pointer;
 }
 
+.rosalution-button:hover{
+  background-color: var(--rosalution-purple-200);
+}
+
 .primary-button {
   background-color: var(--rosalution-purple-100);
   color: var(--rosalution-purple-300);
@@ -39,13 +43,15 @@ html {
   box-sizing: border-box;
 }
 
-.rosalution-button:hover{
-  background-color: var(--rosalution-purple-200);
+.primary-button:disabled {
+  background-color: var(--rosalution-purple-100);
+  color: var(--rosalution-purple-300);
+  opacity: 50%;
 }
 
-
-.primary-button:hover {
+.primary-button:hover:enabled {
   background-color: var(--rosalution-purple-200);
+  color: var(--rosalution-purple-100);
 }
 
 .secondary-button {

--- a/frontend/test/components/AnalysisView/DiscussionPost.spec.js
+++ b/frontend/test/components/AnalysisView/DiscussionPost.spec.js
@@ -18,6 +18,6 @@ describe('DiscussionPost.vue', () => {
   });
 
   it('Vue instance exists and it is an object', () => {
-    expect(typeof wrapper).toBe('object');
+    expect(typeof wrapper).to.not.be.undefined;
   });
 });

--- a/frontend/test/components/AnalysisView/DiscussionSection.spec.js
+++ b/frontend/test/components/AnalysisView/DiscussionSection.spec.js
@@ -1,4 +1,4 @@
-import {it, expect, describe, beforeEach, vi} from 'vitest';
+import {it, expect, describe, beforeEach} from 'vitest';
 import {shallowMount} from '@vue/test-utils';
 
 import DiscussionSection from '../../../src/components/AnalysisView/DiscussionSection.vue';
@@ -24,20 +24,31 @@ describe('DiscussionSection.vue', () => {
   it('Should emit a discussion:new-post event when the publish button is pressed', async () => {
     await wrapper.setData({newPostContent: 'Test post content'});
 
+    const newDiscussionButton = wrapper.find('[data-test=new-discussion-button]');
+    await newDiscussionButton.trigger('click');
+
     const publishNewDiscussionButton = wrapper.find('[data-test=new-discussion-publish]');
     await publishNewDiscussionButton.trigger('click');
 
     const emittedObjects = wrapper.emitted()['discussion:new-post'][0];
 
-    expect(emittedObjects[0]).toBe('Test post content');
+    expect(emittedObjects[0]).to.include('Test post content');
   });
 
-  // Placeholder test
-  it('Should print to console when the cancelled button is pressed', async () => {
-    const cancelNewDiscussionButton = wrapper.find('[data-test=new-discussion-cancel]');
+  it('Should not be able to publish a post if the new post content field is empty', async () => {
+    const newDiscussionButton = wrapper.find('[data-test=new-discussion-button]');
+    await newDiscussionButton.trigger('click');
 
-    vi.spyOn(console, 'log');
-    await cancelNewDiscussionButton.trigger('click');
-    expect(console.log).toHaveBeenCalled();
+    const publishNewDiscussionButton = wrapper.find('[data-test=new-discussion-publish]');
+    expect(publishNewDiscussionButton.attributes().disabled).to.not.be.undefined;
+  });
+
+  it('Should close the new discussion post field when the cancel button is pressed', async () => {
+    const newDiscussionButton = wrapper.find('[data-test=new-discussion-button]');
+    await newDiscussionButton.trigger('click');
+
+    const newDiscussionCancelButton = wrapper.find('[data-test=new-discussion-cancel]');
+
+    await newDiscussionCancelButton.trigger('click');
   });
 });

--- a/system-tests/e2e/discussions_analysis.cy.js
+++ b/system-tests/e2e/discussions_analysis.cy.js
@@ -9,11 +9,33 @@ describe('discussions_analysis.cy.js', () => {
     it('should publish a new post to the discussion section', () => {
         cy.get('#Discussion').should('exist');
 
+        cy.get('[data-test="new-discussion-button"]').click()
+
         cy.get('[data-test="discussion-post"]').should('have.length', 3);
 
         cy.get('[data-test="new-discussion-input"]').type("System Test Text");
         cy.get('[data-test="new-discussion-publish"]').click();
 
         cy.get('[data-test="discussion-post"]').should('have.length', 4);
-    })
+    });
+
+    it('should not be able to publish a post with no text in the new discussion field', () => {
+        cy.get('#Discussion').should('exist');
+
+        cy.get('[data-test="new-discussion-button"]').click()
+        cy.get('[data-test="new-discussion-publish"]').should('be.disabled')
+    });
+
+    it('should cancel a new post, close the new post field, and not post anything', () => {
+        cy.get('#Discussion').should('exist');
+
+        cy.get('[data-test="new-discussion-button"]').click()
+
+        cy.get('[data-test="new-discussion-input"]').type("System Test Text");
+        cy.get('[data-test="new-discussion-cancel"]').click();
+
+        cy.get('[data-test="new-discussion-input"]').should('not.exist');
+
+        cy.get('[data-test="discussion-post"]').should('have.length', 3);
+    });
 });


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

[https://www.wrike.com/open.htm?id=1206938761](https://www.wrike.com/open.htm?id=1206938761)

**Changes made:**

- Clicking the "New Discussion" button opens a new field below the line
- Publishing a post closes the "New Discussion" field and clears the new post text input
  - Still performs the expected emit to publish the post
  - If there is no text in the input field, the publish button is disabled
- Cancelling a post closes the "New Discussion" field and clears the new post text input
- Updated Frontend unit tests and System tests to reflect the changes
  - The Discussion Section Frontend unit tests updated to use chai
- Updated the CSS to be closer to the Figma design


**To Review:**

- [x] Static Analysis by Reviewer
- [ ] Does the "New Discussion" button toggle the new post field?
  To check this run the following commands:
  ``` bash
  # From the root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker compose up --build
  ```
  - Go to [https://local.rosalution.cgds/rosalution](https://local.rosalution.cgds/rosalution)
  - Login with `developer`
  - Click on the `CPAM0002` analysis card
  - Click the `Discussion` button on the top bar or Scroll down to `Discussion` section
  - Click the `New Discussion` button
    - [ ] Is the `Publish` button disabled with no text in the field
    - [ ] Does clicking the `Cancel` button close the field
    - [ ] Are you able to publish a post by entering texy?
- [ ] All Github Actions checks have passed.

---

**Discussion field**

![Screenshot 2023-12-05 at 11 29 18 AM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/57523c82-88a4-4383-8a72-5b940a7a7025)

**Discussion field after clicking the `New Field` button, `Publish` disabled**

![Screenshot 2023-12-05 at 11 27 37 AM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/7b4cf9e8-e615-47d6-907b-3ebdac76cc2b)

**Discussion field after clicking the `New Field` button, Text entered and `Published` enabled**

![Screenshot 2023-12-05 at 11 27 48 AM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/53155bb8-2a88-4859-b86e-6fcfc9d1695b)

**Discussion section after publishing a post**

![Screenshot 2023-12-05 at 11 28 03 AM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/8d975f0c-9b53-46e8-ae75-c9bfd3364b0b)



