### PR TITLE
[Backend] Update the importer to include adding a discussion section in each new analysis

### DIFF
--- a/backend/src/core/phenotips_importer.py
+++ b/backend/src/core/phenotips_importer.py
@@ -42,6 +42,8 @@ class PhenotipsImporter:
 
         analysis_data = self.import_analysis_data(phenotips_json_data, phenotips_variants, phenotips_json_data["genes"])
 
+        analysis_data['discussions'] = []
+        analysis_data['supporting_evidence_files'] = []
         analysis_data['timeline'] = []
         return analysis_data
 

--- a/etc/fixtures/initial-seed/analyses.json
+++ b/etc/fixtures/initial-seed/analyses.json
@@ -298,9 +298,7 @@
             ]
          }
       ],
-      "supporting_evidence_files":[
-         
-      ],
+      "supporting_evidence_files":[],
       "timeline":[
          {
             "event":"create",
@@ -614,6 +612,7 @@
             ]
          }
       ],
+      "supporting_evidence_files":[],
       "timeline":[
          {
             "event":"create",
@@ -914,6 +913,7 @@
             ]
          }
       ],
+      "supporting_evidence_files":[],
       "timeline":[
          {
             "event":"create",
@@ -1247,6 +1247,7 @@
             ]
          }
       ],
+      "supporting_evidence_files":[],
       "timeline":[
          {
             "event":"create",
@@ -1498,6 +1499,8 @@
             ]
          }
       ],
+      "discussions":[],
+      "supporting_evidence_files":[],
       "timeline":[
          {
             "event":"create",
@@ -1532,9 +1535,7 @@
             "username":"developer"
          }
       ],
-      "third_party_links":[
-         
-      ],
+      "third_party_links":[],
       "genomic_units":[
          {
             "gene":"DLG4",
@@ -1861,8 +1862,7 @@
             ]
          }
       ],
-      "supporting_evidence_files":[
-         
-      ]
+      "discussions":[],
+      "supporting_evidence_files":[]
    }
 ]


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## Pull Request Details

[https://www.wrike.com/open.htm?id=1206943181](https://www.wrike.com/open.htm?id=1206943181)
<!-- Note: Title your Pull Request with an appropriate title corresponding to the Issue title -->
Changes made:

This pull request is intended to create consistency with how Analysis documents are created
- Updates the `PhenotipsImporter.py` to add both the `discussions` and `supporting_evidence_files` keys to every uploaded analysis.
  - Assigns to empty arrays
- Updates the existing fixtures to include the keys
  - Consistent fixture data to have empty arrays if no entries

**To Review:**
- [x] Static Analysis by Reviewer
- [x] Deploy and upload a new analysis for local Rosalution
  To check this run the following commands:
  ``` bash
  # from the root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker compose up --build -d
  ```
  - Go to [http://local.rosalution.cgds/rosalution](http://local.rosalution.cgds/rosalution)
  - Login with `developer`
  - Click on the card with the `+`
  - Upload a new analysis from: ./etc/fixtures/import
    - e.g. `C-PAM0042.json`
- [x] Does the Analysis have the new fields upon upload?
  ```bash
  # Find the container name running mongo
  docker ps

  docker exec -it <mongo_container_name> mongosh rosalution_db

  Example:

  docker exec -it rosalution-rosalution-db-1 mongosh rosalution_db

  # Ensure the fields were created on upload

  db.analyses.find({"name": "CPAM0042"})
  ```
- [x] All Github Actions checks have passed.

---

![Screenshot 2023-12-12 at 1 33 08 PM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/37cf98d1-226e-4ce5-a85a-df6701d2f146)

![Screenshot 2023-12-12 at 1 33 18 PM](https://github.com/uab-cgds-worthey/rosalution/assets/5799712/e2d74502-d38e-419e-816d-ad3a4d8da7cb)

<img width="475" alt="Screenshot 2023-12-12 at 1 37 55 PM" src="https://github.com/uab-cgds-worthey/rosalution/assets/5799712/623f5944-7f7f-4c18-9b3d-07091662420a">
