### PR TITLE
System test dialog chrome failure investigation

### DIFF
--- a/system-tests/e2e/discussions_analysis.cy.js
+++ b/system-tests/e2e/discussions_analysis.cy.js
@@ -52,6 +52,10 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('@newDiscussion')
         .find('.grey-rounded-menu > :nth-child(2)')
         .contains('Delete')
+        .trigger('mouseover');
+
+    cy.get('@newDiscussion')
+        .find('.grey-rounded-menu > :nth-child(2)')
         .click();
 
     cy.get('[data-test="notification-dialog"]').find('[data-test="confirm-button"]').contains('Delete').click();
@@ -132,6 +136,10 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('@existingDiscussion')
         .find('.grey-rounded-menu > :nth-child(1)')
         .contains('Edit')
+        .trigger('mouseover');
+
+    cy.get('@existingDiscussion')
+        .find('.grey-rounded-menu > :nth-child(1)')
         .click();
 
     cy.get('[data-test="edit-discussion-input"]').clear();

--- a/system-tests/e2e/discussions_analysis.cy.js
+++ b/system-tests/e2e/discussions_analysis.cy.js
@@ -1,47 +1,41 @@
 describe('discussions_analysis.cy.js', () => {
   beforeEach(() => {
     cy.resetDatabase();
-    cy.visit('/');
-    cy.get('.analysis-card').first().click();
-    cy.get('[href="#Discussion"]').click();
+    cy.visit('/analysis/CPAM0002/#Discussion');
   });
 
-  it('should publish a new post to the discussion section', () => {
-    cy.get('#Discussion').should('exist');
+  // it('should have a discussion section', () => {
+  //   cy.get('#Discussion').should('exist');
+  // });
 
-    cy.get('[data-test="new-discussion-button"]').click();
+  // it('should publish a new post to the discussion section', () => {
+  //   cy.get('[data-test="new-discussion-button"]').click();
 
-    cy.get('[data-test="discussion-post"]').should('have.length', 3);
+  //   cy.get('[data-test="discussion-post"]').should('have.length', 3);
 
-    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-    cy.get('[data-test="new-discussion-publish"]').click();
+  //   cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+  //   cy.get('[data-test="new-discussion-publish"]').click();
 
-    cy.get('[data-test="discussion-post"]').should('have.length', 4);
-  });
+  //   cy.get('[data-test="discussion-post"]').should('have.length', 4);
+  // });
 
-  it('should not be able to publish a post with no text in the new discussion field', () => {
-    cy.get('#Discussion').should('exist');
+  // it('should not be able to publish a post with no text in the new discussion field', () => {
+  //   cy.get('[data-test="new-discussion-button"]').click();
+  //   cy.get('[data-test="new-discussion-publish"]').should('be.disabled');
+  // });
 
-    cy.get('[data-test="new-discussion-button"]').click();
-    cy.get('[data-test="new-discussion-publish"]').should('be.disabled');
-  });
+  // it('should cancel a new post, close the new post field, and not post anything', () => {
+  //   cy.get('[data-test="new-discussion-button"]').click();
 
-  it('should cancel a new post, close the new post field, and not post anything', () => {
-    cy.get('#Discussion').should('exist');
+  //   cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+  //   cy.get('[data-test="new-discussion-cancel"]').click();
 
-    cy.get('[data-test="new-discussion-button"]').click();
+  //   cy.get('[data-test="new-discussion-input"]').should('not.exist');
 
-    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-    cy.get('[data-test="new-discussion-cancel"]').click();
-
-    cy.get('[data-test="new-discussion-input"]').should('not.exist');
-
-    cy.get('[data-test="discussion-post"]').should('have.length', 3);
-  });
+  //   cy.get('[data-test="discussion-post"]').should('have.length', 3);
+  // });
 
   it('should publish a new post to the discussion section then proceed to delete it successfully', () => {
-    cy.get('#Discussion').should('exist');
-
     cy.get('[data-test="new-discussion-button"]').click();
 
     cy.get('[data-test="new-discussion-input"]').type('System Test Text');
@@ -49,11 +43,13 @@ describe('discussions_analysis.cy.js', () => {
 
     cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-    cy.get('[data-test="discussion-post"]')
-        .eq(3)
-        .find('[data-test="discussion-post-header"]')
+    cy.get('[data-test="discussion-post"]').eq(3).as('newDiscussion')
+
+    cy.get('@newDiscussion')
         .find('[data-test="discussion-post-context-menu"]')
-        .click()
+        .click();
+    
+    cy.get('@newDiscussion')
         .find('.grey-rounded-menu > :nth-child(2)')
         .contains('Delete')
         .click();
@@ -63,83 +59,83 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('[data-test="discussion-post"]').should('have.length', 3);
   });
 
-  it('should publish a new post to the discussion section, delete the post, and cancel the deletion', () => {
-    cy.get('#Discussion').should('exist');
+//   it('should publish a new post to the discussion section, delete the post, and cancel the deletion', () => {
+//     cy.get('#Discussion').should('exist');
 
-    cy.get('[data-test="new-discussion-button"]').click();
+//     cy.get('[data-test="new-discussion-button"]').click();
 
-    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-    cy.get('[data-test="new-discussion-publish"]').click();
+//     cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+//     cy.get('[data-test="new-discussion-publish"]').click();
 
-    cy.get('[data-test="discussion-post"]').should('have.length', 4);
+//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-    cy.get('[data-test="discussion-post"]')
-        .eq(3)
-        .find('[data-test="discussion-post-header"]')
-        .find('[data-test="discussion-post-context-menu"]')
-        .click()
-        .find('.grey-rounded-menu > :nth-child(2)')
-        .contains('Delete')
-        .click();
+//     cy.get('[data-test="discussion-post"]')
+//         .eq(3)
+//         .find('[data-test="discussion-post-header"]')
+//         .find('[data-test="discussion-post-context-menu"]')
+//         .click()
+//         .find('.grey-rounded-menu > :nth-child(2)')
+//         .contains('Delete')
+//         .click();
 
-    cy.get('[data-test="notification-dialog"]').find('[data-test="cancel-button"]').contains('Cancel').click();
+//     cy.get('[data-test="notification-dialog"]').find('[data-test="cancel-button"]').contains('Cancel').click();
 
-    cy.get('[data-test="discussion-post"]').should('have.length', 4);
-  });
+//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
+//   });
 
-  it('Should proceed to edit an existing discussion post and save it', () => {
-    cy.get('[data-test="new-discussion-button"').click();
+//   it('Should proceed to edit an existing discussion post and save it', () => {
+//     cy.get('[data-test="new-discussion-button"').click();
 
-    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-    cy.get('[data-test="new-discussion-publish"]').click();
+//     cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+//     cy.get('[data-test="new-discussion-publish"]').click();
 
-    cy.get('[data-test="discussion-post"]').should('have.length', 4);
+//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-    cy.get('[data-test="discussion-post"]')
-        .eq(3)
-        .find('[data-test="discussion-post-header"]')
-        .find('[data-test="discussion-post-context-menu"]')
-        .click()
-        .find('.grey-rounded-menu > :nth-child(1)')
-        .contains('Edit')
-        .click();
+//     cy.get('[data-test="discussion-post"]')
+//         .eq(3)
+//         .find('[data-test="discussion-post-header"]')
+//         .find('[data-test="discussion-post-context-menu"]')
+//         .click()
+//         .find('.grey-rounded-menu > :nth-child(1)')
+//         .contains('Edit')
+//         .click();
 
-    cy.get('[data-test="edit-discussion-input"]').clear();
-    cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
+//     cy.get('[data-test="edit-discussion-input"]').clear();
+//     cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
 
-    cy.get('[data-test="edit-discussion-save"]').click();
+//     cy.get('[data-test="edit-discussion-save"]').click();
 
-    cy.get('[data-test="discussion-post"]')
-        .eq(3)
-        .find('[data-test="discussion-post-content"]')
-        .should('have.text', 'Editing a system test.');
-  });
+//     cy.get('[data-test="discussion-post"]')
+//         .eq(3)
+//         .find('[data-test="discussion-post-content"]')
+//         .should('have.text', 'Editing a system test.');
+//   });
 
-  it('Should proceed to edit a discussion post and then cancel it leaving the original post intact', () => {
-    cy.get('[data-test="new-discussion-button"').click();
+//   it('Should proceed to edit a discussion post and then cancel it leaving the original post intact', () => {
+//     cy.get('[data-test="new-discussion-button"').click();
 
-    cy.get('[data-test="new-discussion-input"]').type('System Test Text.');
-    cy.get('[data-test="new-discussion-publish"]').click();
+//     cy.get('[data-test="new-discussion-input"]').type('System Test Text.');
+//     cy.get('[data-test="new-discussion-publish"]').click();
 
-    cy.get('[data-test="discussion-post"]').should('have.length', 4);
+//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-    cy.get('[data-test="discussion-post"]')
-        .eq(3)
-        .find('[data-test="discussion-post-header"]')
-        .find('[data-test="discussion-post-context-menu"]')
-        .click()
-        .find('.grey-rounded-menu > :nth-child(1)')
-        .contains('Edit')
-        .click();
+//     cy.get('[data-test="discussion-post"]')
+//         .eq(3)
+//         .find('[data-test="discussion-post-header"]')
+//         .find('[data-test="discussion-post-context-menu"]')
+//         .click()
+//         .find('.grey-rounded-menu > :nth-child(1)')
+//         .contains('Edit')
+//         .click();
 
-    cy.get('[data-test="edit-discussion-input"]').clear();
-    cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
+//     cy.get('[data-test="edit-discussion-input"]').clear();
+//     cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
 
-    cy.get('[data-test="edit-discussion-cancel"]').click();
+//     cy.get('[data-test="edit-discussion-cancel"]').click();
 
-    cy.get('[data-test="discussion-post"]')
-        .eq(3)
-        .find('[data-test="discussion-post-content"]')
-        .should('have.text', 'System Test Text.');
-  });
+//     cy.get('[data-test="discussion-post"]')
+//         .eq(3)
+//         .find('[data-test="discussion-post-content"]')
+//         .should('have.text', 'System Test Text.');
+//   });
 });

--- a/system-tests/e2e/discussions_analysis.cy.js
+++ b/system-tests/e2e/discussions_analysis.cy.js
@@ -4,36 +4,36 @@ describe('discussions_analysis.cy.js', () => {
     cy.visit('/analysis/CPAM0002/#Discussion');
   });
 
-  // it('should have a discussion section', () => {
-  //   cy.get('#Discussion').should('exist');
-  // });
+  it('should have a discussion section', () => {
+    cy.get('#Discussion').should('exist');
+  });
 
-  // it('should publish a new post to the discussion section', () => {
-  //   cy.get('[data-test="new-discussion-button"]').click();
+  it('should publish a new post to the discussion section', () => {
+    cy.get('[data-test="new-discussion-button"]').click();
 
-  //   cy.get('[data-test="discussion-post"]').should('have.length', 3);
+    cy.get('[data-test="discussion-post"]').should('have.length', 3);
 
-  //   cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-  //   cy.get('[data-test="new-discussion-publish"]').click();
+    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+    cy.get('[data-test="new-discussion-publish"]').click();
 
-  //   cy.get('[data-test="discussion-post"]').should('have.length', 4);
-  // });
+    cy.get('[data-test="discussion-post"]').should('have.length', 4);
+  });
 
-  // it('should not be able to publish a post with no text in the new discussion field', () => {
-  //   cy.get('[data-test="new-discussion-button"]').click();
-  //   cy.get('[data-test="new-discussion-publish"]').should('be.disabled');
-  // });
+  it('should not be able to publish a post with no text in the new discussion field', () => {
+    cy.get('[data-test="new-discussion-button"]').click();
+    cy.get('[data-test="new-discussion-publish"]').should('be.disabled');
+  });
 
-  // it('should cancel a new post, close the new post field, and not post anything', () => {
-  //   cy.get('[data-test="new-discussion-button"]').click();
+  it('should cancel a new post, close the new post field, and not post anything', () => {
+    cy.get('[data-test="new-discussion-button"]').click();
 
-  //   cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-  //   cy.get('[data-test="new-discussion-cancel"]').click();
+    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+    cy.get('[data-test="new-discussion-cancel"]').click();
 
-  //   cy.get('[data-test="new-discussion-input"]').should('not.exist');
+    cy.get('[data-test="new-discussion-input"]').should('not.exist');
 
-  //   cy.get('[data-test="discussion-post"]').should('have.length', 3);
-  // });
+    cy.get('[data-test="discussion-post"]').should('have.length', 3);
+  });
 
   it('should publish a new post to the discussion section then proceed to delete it successfully', () => {
     cy.get('[data-test="new-discussion-button"]').click();
@@ -43,12 +43,12 @@ describe('discussions_analysis.cy.js', () => {
 
     cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-    cy.get('[data-test="discussion-post"]').eq(3).as('newDiscussion')
+    cy.get('[data-test="discussion-post"]').eq(3).as('newDiscussion');
 
     cy.get('@newDiscussion')
         .find('[data-test="discussion-post-context-menu"]')
         .click();
-    
+
     cy.get('@newDiscussion')
         .find('.grey-rounded-menu > :nth-child(2)')
         .contains('Delete')
@@ -59,83 +59,89 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('[data-test="discussion-post"]').should('have.length', 3);
   });
 
-//   it('should publish a new post to the discussion section, delete the post, and cancel the deletion', () => {
-//     cy.get('#Discussion').should('exist');
+  it('should publish a new post to the discussion section, delete the post, and cancel the deletion', () => {
+    cy.get('#Discussion').should('exist');
 
-//     cy.get('[data-test="new-discussion-button"]').click();
+    cy.get('[data-test="new-discussion-button"]').click();
 
-//     cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-//     cy.get('[data-test="new-discussion-publish"]').click();
+    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+    cy.get('[data-test="new-discussion-publish"]').click();
 
-//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
+    cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-//     cy.get('[data-test="discussion-post"]')
-//         .eq(3)
-//         .find('[data-test="discussion-post-header"]')
-//         .find('[data-test="discussion-post-context-menu"]')
-//         .click()
-//         .find('.grey-rounded-menu > :nth-child(2)')
-//         .contains('Delete')
-//         .click();
+    cy.get('[data-test="discussion-post"]').eq(3).as('newDiscussion');
 
-//     cy.get('[data-test="notification-dialog"]').find('[data-test="cancel-button"]').contains('Cancel').click();
+    cy.get('@newDiscussion')
+        .find('[data-test="discussion-post-context-menu"]')
+        .click();
 
-//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
-//   });
+    cy.get('@newDiscussion')
+        .find('.grey-rounded-menu > :nth-child(2)')
+        .contains('Delete')
+        .click();
 
-//   it('Should proceed to edit an existing discussion post and save it', () => {
-//     cy.get('[data-test="new-discussion-button"').click();
+    cy.get('[data-test="notification-dialog"]').find('[data-test="cancel-button"]').contains('Cancel').click();
 
-//     cy.get('[data-test="new-discussion-input"]').type('System Test Text');
-//     cy.get('[data-test="new-discussion-publish"]').click();
+    cy.get('[data-test="discussion-post"]').should('have.length', 4);
+  });
 
-//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
+  it('Should proceed to edit an existing discussion post and save it', () => {
+    cy.get('[data-test="new-discussion-button"').click();
 
-//     cy.get('[data-test="discussion-post"]')
-//         .eq(3)
-//         .find('[data-test="discussion-post-header"]')
-//         .find('[data-test="discussion-post-context-menu"]')
-//         .click()
-//         .find('.grey-rounded-menu > :nth-child(1)')
-//         .contains('Edit')
-//         .click();
+    cy.get('[data-test="new-discussion-input"]').type('System Test Text');
+    cy.get('[data-test="new-discussion-publish"]').click();
 
-//     cy.get('[data-test="edit-discussion-input"]').clear();
-//     cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
+    cy.get('[data-test="discussion-post"]').should('have.length', 4);
 
-//     cy.get('[data-test="edit-discussion-save"]').click();
+    cy.get('[data-test="discussion-post"]').eq(3).as('existingDiscussion');
 
-//     cy.get('[data-test="discussion-post"]')
-//         .eq(3)
-//         .find('[data-test="discussion-post-content"]')
-//         .should('have.text', 'Editing a system test.');
-//   });
+    cy.get('@existingDiscussion')
+        .find('[data-test="discussion-post-context-menu"]')
+        .click();
 
-//   it('Should proceed to edit a discussion post and then cancel it leaving the original post intact', () => {
-//     cy.get('[data-test="new-discussion-button"').click();
+    cy.get('@existingDiscussion')
+        .find('.grey-rounded-menu > :nth-child(1)')
+        .contains('Edit')
+        .click();
 
-//     cy.get('[data-test="new-discussion-input"]').type('System Test Text.');
-//     cy.get('[data-test="new-discussion-publish"]').click();
+    cy.get('[data-test="edit-discussion-input"]').clear();
+    cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
 
-//     cy.get('[data-test="discussion-post"]').should('have.length', 4);
+    cy.get('[data-test="edit-discussion-save"]').click();
 
-//     cy.get('[data-test="discussion-post"]')
-//         .eq(3)
-//         .find('[data-test="discussion-post-header"]')
-//         .find('[data-test="discussion-post-context-menu"]')
-//         .click()
-//         .find('.grey-rounded-menu > :nth-child(1)')
-//         .contains('Edit')
-//         .click();
+    cy.get('[data-test="discussion-post"]')
+        .eq(3)
+        .find('[data-test="discussion-post-content"]')
+        .should('have.text', 'Editing a system test.');
+  });
 
-//     cy.get('[data-test="edit-discussion-input"]').clear();
-//     cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
+  it('Should proceed to edit a discussion post and then cancel it leaving the original post intact', () => {
+    cy.get('[data-test="new-discussion-button"').click();
 
-//     cy.get('[data-test="edit-discussion-cancel"]').click();
+    cy.get('[data-test="new-discussion-input"]').type('System Test Text.');
+    cy.get('[data-test="new-discussion-publish"]').click();
 
-//     cy.get('[data-test="discussion-post"]')
-//         .eq(3)
-//         .find('[data-test="discussion-post-content"]')
-//         .should('have.text', 'System Test Text.');
-//   });
+    cy.get('[data-test="discussion-post"]').should('have.length', 4);
+
+    cy.get('[data-test="discussion-post"]').eq(3).as('existingDiscussion');
+
+    cy.get('@existingDiscussion')
+        .find('[data-test="discussion-post-context-menu"]')
+        .click();
+
+    cy.get('@existingDiscussion')
+        .find('.grey-rounded-menu > :nth-child(1)')
+        .contains('Edit')
+        .click();
+
+    cy.get('[data-test="edit-discussion-input"]').clear();
+    cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
+
+    cy.get('[data-test="edit-discussion-cancel"]').click();
+
+    cy.get('[data-test="discussion-post"]')
+        .eq(3)
+        .find('[data-test="discussion-post-content"]')
+        .should('have.text', 'System Test Text.');
+  });
 });

--- a/system-tests/e2e/discussions_analysis.cy.js
+++ b/system-tests/e2e/discussions_analysis.cy.js
@@ -52,11 +52,7 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('@newDiscussion')
         .find('.grey-rounded-menu > :nth-child(2)')
         .contains('Delete')
-        .trigger('mouseover');
-
-    cy.get('@newDiscussion')
-        .find('.grey-rounded-menu > :nth-child(2)')
-        .click();
+        .click({force: true});
 
     cy.get('[data-test="notification-dialog"]').find('[data-test="confirm-button"]').contains('Delete').click();
 
@@ -82,7 +78,7 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('@newDiscussion')
         .find('.grey-rounded-menu > :nth-child(2)')
         .contains('Delete')
-        .click();
+        .click({force: true});
 
     cy.get('[data-test="notification-dialog"]').find('[data-test="cancel-button"]').contains('Cancel').click();
 
@@ -106,7 +102,7 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('@existingDiscussion')
         .find('.grey-rounded-menu > :nth-child(1)')
         .contains('Edit')
-        .click();
+        .click({force: true});
 
     cy.get('[data-test="edit-discussion-input"]').clear();
     cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');
@@ -136,11 +132,7 @@ describe('discussions_analysis.cy.js', () => {
     cy.get('@existingDiscussion')
         .find('.grey-rounded-menu > :nth-child(1)')
         .contains('Edit')
-        .trigger('mouseover');
-
-    cy.get('@existingDiscussion')
-        .find('.grey-rounded-menu > :nth-child(1)')
-        .click();
+        .click({force: true});
 
     cy.get('[data-test="edit-discussion-input"]').clear();
     cy.get('[data-test="edit-discussion-input"]').type('Editing a system test.');

--- a/system-tests/e2e/rosalution_analysis.cy.js
+++ b/system-tests/e2e/rosalution_analysis.cy.js
@@ -49,7 +49,7 @@ describe('As a Clinical Analyst using Rosalution for analysis', () => {
 
   it('should allow the user to navigate to a third party link after adding one', () => {
     cy.get('.grey-rounded-menu').invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;');
-    cy.get('[data-test="user-menu"] > .grey-rounded-menu').contains('Attach Monday.com').click();
+    cy.get('[data-test="user-menu"] > .grey-rounded-menu').contains('Attach Monday.com').click({force: true});
     cy.get('.grey-rounded-menu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
 
     cy.get('[data-test="link-input"]').type('https://www.monday.com');


### PR DESCRIPTION

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

## Pull Request Details

Wrike Ticket- [Investigate System Test Failure on Opening Context Menu to modify discussions](https://www.wrike.com/open.htm?id=1357850231)

Changes made:

- Changed the button clicks on the context menu for system testing on discussions to be forced.  The context menu isn't changing its css visibility because its not registering programmatically the focus event.  When trying to force focus on the element it said the element was not focusable.  The context menu's functionality is tested sufficiently in unit testing and user testing.  Am comfortable with using 'force' for the time being to continue the tests. They were working at some point and due to an update to one of the packages, it has caused this bizarre inconsistent failure.

**To Review:**

- [ ] Static Analysis by Reviewer
- [ ] All Github Actions checks have passed (including system testing)
