### PR TITLE
Disable unnecessary warning urllib3

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -6,6 +6,9 @@ import logging.config
 
 from os import path
 
+import urllib3
+urllib3.disable_warnings()
+
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,17 +3,16 @@ End points for backend
 """
 import logging
 import logging.config
-
 from os import path
-
 import urllib3
-urllib3.disable_warnings()
 
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
 
 from .config import get_settings
 from .routers import analysis_router, annotation_router, auth_router
+
+urllib3.disable_warnings()
 
 DESCRIPTION = """
 rosalution REST API assists researchers study 🧬 variation in patients 🧑🏾‍🤝‍🧑🏼


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

## Pull Request Details

Wrike Ticket - [Investigate resolving the "Unverified HTTPS request warning' made to host](https://www.wrike.com/open.htm?id=1383710529)

Changes made:

- Disabling the warnings from urllib3 to avoid the logs being overloaded

**To Review:**

- [x] Static Analysis by Reviewer
- [x] The changes made to the backend service disable the log `/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py:1103: InsecureRequestWarning: Unverified HTTPS request is being made to host` to overrun the logs when annotating variants

  To check this run the following commands:

  ``` bash
  # From the root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker compose up --build
  ```

  1. Go to: https://local.rosalution.cgds/rosalution/
  2. Login as 'developer'
  3. In a terminal, follow the docker logs for the Rosalution backend service
    ```bash
    docker logs --follow rosalution-backend-1
    ```
  5. In browser in Rosalution, click 'Create New Analysis' card and import 'C-PAM0076.json' within the 'etc/fixtures/import'. and follow logs to see if the warning is visible.
  6. In browser in Rosalution, click 'Create New Analysis' card and import 'C-PAM0075.json' within the 'etc/fixtures/import'. and follow logs to see if the warning is visible.
- [x] All Github Actions checks have passed.

