### PR TITLE
Draft script to run on every Cilipathies case to update landing page with new sections and fields

### DIFF
--- a/etc/fixtures/import/CILI_2_5K_ARMC9_L510V.json
+++ b/etc/fixtures/import/CILI_2_5K_ARMC9_L510V.json
@@ -1,0 +1,19 @@
+{
+  "date": "2022-07-16T16:07:38.000Z",
+  "external_id": "CILI_2_5K ARMC9_L510V",
+  "variants": [
+      {
+          "transcript": "NM_025139.6",
+          "gene": "ENSG00000135931",
+          "reference_genome": "GRCh37",
+          "protein": "p.Leu510Val",
+          "cdna": "c.1528C>G"
+      }
+  ],
+  "genes": [
+      {
+          "gene": "ARMC9",
+          "id": "ENSG00000135931"
+      }
+  ]
+}

--- a/etc/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
+++ b/etc/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
@@ -1,5 +1,5 @@
 const usage = `
-mongosh --eval 'var ciliAnalysis=""' /tmp/fixtures/migrations/ciliopathies-landing-page.js
+mongosh --eval 'var ciliAnalysis=""' /tmp/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
 
 Script Options:
     help : Bool : Optional
@@ -10,9 +10,9 @@ Run mongosh help for mongosh connection and authentication usage.
 
 Example:
 
-    mongosh --host localhost --port 27017 --eval 'var help=True;' /tmp/fixtures/migrations/ciliopathies-landing-page.js
+    mongosh --host localhost --port 27017 --eval 'var help=True;' /tmp/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
 
-    docker exec -it <rosalution_db_container> mongosh --eval 'var ciliAnalysis="CILI_2_5K ARMC9_L510V"' /tmp/fixtures/migrations/ciliopathies-landing-page.js
+    docker exec -it <rosalution_db_container> mongosh --eval 'var ciliAnalysis="CILI_2_5K ARMC9_L510V"' /tmp/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
 `
 
 if (help === true) {

--- a/etc/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
+++ b/etc/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
@@ -1,0 +1,129 @@
+const usage = `
+mongosh --eval 'var ciliAnalysis=""' /tmp/fixtures/migrations/ciliopathies-landing-page.js
+
+Script Options:
+    help : Bool : Optional
+        - If True print this help message
+    ciliAnalysis : String : Required
+
+Run mongosh help for mongosh connection and authentication usage.
+
+Example:
+
+    mongosh --host localhost --port 27017 --eval 'var help=True;' /tmp/fixtures/migrations/ciliopathies-landing-page.js
+
+    docker exec -it <rosalution_db_container> mongosh --eval 'var ciliAnalysis="CILI_2_5K ARMC9_L510V"' /tmp/fixtures/migrations/ciliopathies-landing-page.js
+`
+
+if (help === true) {
+    print(usage);
+    quit(1);
+}
+
+if (typeof databaseName === 'undefined') {
+    databaseName = 'rosalution_db';
+} else if (typeof databaseName !== 'string') {
+    print('databaseName must be a string');
+    print(usage);
+    quit(1);
+}
+
+if(typeof ciliAnalysis === 'undefined' || typeof ciliAnalysis !== 'string' || ciliAnalysis == '') {
+    print('ciliAnalysis needs to be defined and must be a string');
+    print(usage);
+    quit(1);
+}
+
+print(`Converting ${ciliAnalysis}'s Analysis View from CPAM to Ciliopathies...`)
+
+// New Ciliopathy specific fields
+
+const databaseTextField = {
+    "type":"section-text",
+    "field":"Database",
+    "value":[]
+}
+
+const patientRelatedVariantEvidenceField = {
+    "type": "section-supporting-evidence",
+    "field": "Patient Related Variants",
+    "value": []
+}
+
+const resourcesSection = {
+    "header": "Resources",
+    "content": [
+        {
+            "type": "section-text",
+            "field": "Purchased Antibody Catalog #",
+            "value": []
+        },
+        {
+            "type": "section-text",
+            "field": "Physical Resources",
+            "value": []
+        }
+    ]
+}
+
+const reportingSection = {
+    "header": "Reporting",
+    "content": [
+        {
+            "type": "section-supporting-evidence",
+            "field": "Benchling",
+            "value": []
+        }
+    ]
+}
+
+// Getting the database driver for mongo
+db = db.getSiblingDB(databaseName)
+
+// Getting the analysis and inserting the new sections
+// Note: This will insert the fields twice if run twice
+try {
+    var analysis = db.analyses.findOne({name: ciliAnalysis})
+    print(`Found ${ciliAnalysis} in mongodb...`)
+
+    var index = 0;
+
+    console.log(analysis.sections)
+
+    for(section in analysis.sections) {        
+        if(analysis.sections[section].header == 'Brief') {
+            print(`Inserting the Database text field into the Brief section...`)
+            analysis.sections[section]['content'].splice(1, 0, databaseTextField);
+
+            print(`Inserting the Patient Related Variants Evidence field into the Brief section...`)
+            analysis.sections[section]['content'].push(patientRelatedVariantEvidenceField)
+        }
+    }
+
+    for(section in analysis.sections) {
+        if(analysis.sections[section].header == 'Pedigree') {
+            console.log(`Section #: ${section}, Header: ${analysis.sections[section].header}`)
+            print(`Inserting the Resources section into the analysis...`)
+            analysis.sections.splice(section, 0, resourcesSection)
+            break;
+        }
+    }
+
+    for(section in analysis.sections) {
+        if(analysis.sections[section].header == 'Model Goals') {
+            console.log(`Section #: ${section}, Header: ${analysis.sections[section].header}`)
+            print(`Inserting the Reporting section into the analysis...`)
+            analysis.sections.splice(section + 1, 0, reportingSection)
+            break;
+        }
+    }
+
+    print(`Writing to mongodb...`)
+    db.analyses.updateOne({'_id': analysis._id}, {'$set': analysis})
+
+    print(`Success! Done.`)
+} catch(e) {
+    console.log(e.stack);
+    console.log(usage);
+    quit(1);
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] My changes generate no new warnings.

## Pull Request Details

[https://www.wrike.com/open.htm?id=1472359818](https://www.wrike.com/open.htm?id=1472359818)

Changes made:

- Added a new migration script `etc/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js` that will convert a CPAM analysis landing page to a Ciliopathies analysis landing page
- Added `etc/fixtures/import/CILI_2_5K_ARMC9_L510V.json` as an example Ciliopathies analysis to upload and test migration

**To Review:**

- [x] Static Analysis by Reviewer
- [x] Start a local version of Roslaution and upload the Ciliopathies analysis
  To check this run the following commands:
  ``` bash
  # From the root of Rosalution
  docker compose down
  docker system prune -a --volumes
  
  docker compose up --build -d
  ```
  - Go to `local.rosalution.cgds/rosalution`
  - Login as `developer`
  - Click on the `Create New Analysis` card
  - Upload the analysis located at `etc/fixtures/import/CILI_2_5K_ARMC9_L510V.json`
- [x] Can you convert the new analysis to contain the new ciliopathies fields?
```bash
docker exec -it rosalution-rosalution-db-1 mongosh --eval 'var ciliAnalysis="CILI_2_5K ARMC9_L510V"' 
/tmp/fixtures/migrations/migrate-cpam-to-ciliopathies-landing-page.js
```
  - Click on the `CILI_2_5K ARMC9_L510V` analysis card
  - Does the landing page have the new sections?
    - Brief
      - Database
      - Patient Level Variant Information
    - Resources
      - Purchased Antibody Catalog #
      - Physical Resources
    - Reporting
      - Benchling


---

### Screenshots (if appropriate)

![Screenshot 2024-09-16 at 4 17 18 PM](https://github.com/user-attachments/assets/7975adec-bf1c-4317-a90e-e0f9d4a0b57a)

![Screenshot 2024-09-16 at 4 17 40 PM](https://github.com/user-attachments/assets/0015dd12-cb51-4765-b2f9-3905cddce2e8)

![Screenshot 2024-09-16 at 4 17 56 PM](https://github.com/user-attachments/assets/7316c017-293b-4f21-925b-7432c7ec3ad9)

