### PR TITLE
Updating Annotation to include a new Subprocess task to run tabix to fetch DITTO scores from LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ data
 *.npmrc
 **/tmp/**
 *.archive
+DITTO_chr*.tsv.gz.tbi
 
 # Log files
 npm-debug.log*

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,8 +4,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 COPY annotation-render-layout.json /app/annotation-render-layout.json
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
-RUN apt-get update
-RUN apt-get install -y samtools=1.16.1-1 tabix=1.16+ds-3
+RUN apt-get update && apt-get install -y --no-install-recommends samtools=1.16.1-1 tabix=1.16+ds-3
 COPY ./src /app/src
 COPY annotation-render-layout.json /app/annotation-render-layout.json
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "info", "--reload"]
@@ -17,8 +16,9 @@ COPY logging.conf /app/logging.conf
 COPY requirements.txt /app/requirements.txt
 COPY annotation-render-layout.json /app/annotation-render-layout.json
 RUN pip install --no-cache-dir -r /app/requirements.txt
-RUN apt-get update
-RUN apt-get install -y samtools=1.16.1-1 tabix=1.16+ds-3
+RUN apt-get update && apt-get install -y --no-install-recommends samtools=1.16.1-1 tabix=1.16+ds-3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 COPY ./src /app/src
 COPY etc/entrypoint-init.sh /app/entrypoint-init.sh
 RUN rm /app/src/routers/dev_router.py

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 COPY annotation-render-layout.json /app/annotation-render-layout.json
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+RUN apt-get update
+RUN apt-get install -y samtools=1.16.1-1 tabix=1.16+ds-3
 COPY ./src /app/src
 COPY annotation-render-layout.json /app/annotation-render-layout.json
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "info", "--reload"]
@@ -15,6 +17,8 @@ COPY logging.conf /app/logging.conf
 COPY requirements.txt /app/requirements.txt
 COPY annotation-render-layout.json /app/annotation-render-layout.json
 RUN pip install --no-cache-dir -r /app/requirements.txt
+RUN apt-get update
+RUN apt-get install -y samtools=1.16.1-1 tabix=1.16+ds-3
 COPY ./src /app/src
 COPY etc/entrypoint-init.sh /app/entrypoint-init.sh
 RUN rm /app/src/routers/dev_router.py

--- a/backend/tests/unit/core/test_annotation_task.py
+++ b/backend/tests/unit/core/test_annotation_task.py
@@ -1,10 +1,13 @@
 """Tests Annotation Tasks and the creation of them"""
 from datetime import date
 from unittest.mock import Mock, patch
+
+import copy
+import subprocess
 import pytest
 import requests
 
-from src.core.annotation_task import AnnotationTaskFactory, ForgeAnnotationTask, \
+from src.core.annotation_task import AnnotationTaskFactory, ForgeAnnotationTask, SubprocessAnnotationTask, \
     HttpAnnotationTask, VersionAnnotationTask
 from src.enums import GenomicUnitType
 from src.core.annotation_unit import AnnotationUnit
@@ -156,6 +159,62 @@ def test_version_extraction(genomic_unit, dataset_name, expected, version_to_ext
     task = get_version_task(genomic_unit, dataset_name)
     actual_version_extraction = task.extract_version(version_to_extract)
     assert actual_version_extraction == expected
+
+
+def test_subprocess_annotation_build_command_with_dependency(subprocess_annotation_ditto_score_task):
+    """ Verifies the subprocess command is built properly to be executed programmatically """
+    expected = ['tabix', 'https://s3.lts.rc.uab.edu/cgds-public/dittodb/DITTO_chrX.tsv.gz', 'chrX:156134910-156134910']
+
+    actual = subprocess_annotation_ditto_score_task.build_command()
+
+    assert expected == actual
+
+
+def test_annotation_task_create_subprocess_task(hgvs_variant_ditto_annotation_unit):
+    """ Verifies the ditto dataset creates a subprocess task """
+    actual_task = AnnotationTaskFactory.create_annotation_task(hgvs_variant_ditto_annotation_unit)
+
+    assert isinstance(actual_task, SubprocessAnnotationTask)
+
+
+def test_ditto_subprocess_annotate(subprocess_annotation_ditto_score_task):
+    """ Tests the completion of a subprocess and extracting the correct result """
+    expected = [{
+        'chrom': 'chr1', 'pos': '156134910', 'ref': 'C', 'alt': 'A', 'transcript': 'ENST00000347559', 'gene': 'LMNA',
+        'classification': 'synonymous_variant', 'ditto': '0.00011253357'
+    }]
+
+    mock_response = Mock(spec=subprocess.CompletedProcess)
+    attrs = {
+        'args': [
+            'tabix', 'https://s3.lts.rc.uab.edu/cgds-public/dittodb/DITTO_chr1.tsv.gz', 'chr1:156134910-156134910'
+        ], 'returncode': 0,
+        'stdout': b'chr1\t156134910\tC\tA\tENST00000347559\tLMNA\tsynonymous_variant\t0.00011253357\n'
+    }
+    mock_response.configure_mock(**attrs)
+
+    with patch('subprocess.run', return_value=mock_response):
+        task = subprocess_annotation_ditto_score_task
+
+        actual_subprocess_result = task.annotate()
+
+        assert expected == actual_subprocess_result
+
+
+def test_ditto_subprocess_annotate_failure(subprocess_annotation_ditto_score_task):
+    """ Assures that the subprocess run function faily gracefully and returns an empty object """
+
+    attrs = {
+        'cmd': ['tabix', 'https://s3.lts.rc.uab.edu/cgds-public/fake-data.gz', 'chr1:156134910-156134910'],
+        'returncode': 1, 'stderr': b''
+    }
+
+    mock_error = subprocess.CalledProcessError(**attrs)
+
+    with patch('subprocess.run', side_effect=mock_error):
+        result = subprocess_annotation_ditto_score_task.annotate()
+
+        assert result == {}
 
 
 ## Fixtures ##
@@ -312,6 +371,32 @@ def fixture_polyphen_prediction_dataset():
     }
 
 
+@pytest.fixture(name="ditto_score_dataset")
+def fixture_ditto_score_dataset():
+    """ Returns a subprocess dataset specifically for ditto """
+
+    return {
+        "data_set": "DITTO",
+        "data_source": "cgds",
+        "genomic_unit_type": "hgvs_variant",
+        "annotation_source_type": "subprocess",
+        "subprocess":
+            "tabix https://s3.lts.rc.uab.edu/cgds-public/dittodb/DITTO_chr{chrom}.tsv.gz chr{chrom}:{pos}-{pos}",
+        "fieldnames": ["chrom", "pos", "ref", "alt", "transcript", "gene", "classification", "ditto"],
+        "delimiter": "\t",
+        "attribute": ".[] += (\"{ensembl_vep_vcf_string}\" | split(\"-\") | {\"vcf_string\": .}) | .[] | " \
+            "select( .chrom == (\"chr\" + .vcf_string[0]) and .vcf_string[1] == .pos and .vcf_string[2] == " \
+            ".ref and .vcf_string[3] == .alt and .transcript ==\"{Ensembl_Transcript_Id}\") | { \"ditto\": .ditto }",
+        "dependencies": [
+            "chrom",
+            "pos",
+            "Ensembl_Transcript_Id",
+            "ensembl_vep_vcf_string"
+        ],
+        "versioning_type": "rosalution"
+    }
+
+
 @pytest.fixture(name="http_annotation_polyphen_prediction")
 def fixture_http_annotation_polyphen_prediction(hgvs_variant_genomic_unit, polyphen_prediction_dataset):
     """An HTTP annotation task with a single dataset"""
@@ -375,3 +460,30 @@ def fixture_genenames_annotation_response():
     Returns an object that contains the actual return output for GENE VMA21
     """
     return {}
+
+
+@pytest.fixture(name="hgvs_variant_ditto_annotation_unit")
+def fixture_hgvs_variant_ditto_annotation_unit(hgvs_variant_genomic_unit, ditto_score_dataset):
+    """ Creates and returns a ditto annotation unit with the required dependencies to run """
+
+    # Creating a copy of the variant fixture
+    ditto_hgvs_variant_genomic_unit = copy.deepcopy(hgvs_variant_genomic_unit)
+
+    # Adding dependencies to the genomic unit for ditto
+    ditto_hgvs_variant_genomic_unit["chrom"] = "X"
+    ditto_hgvs_variant_genomic_unit["pos"] = "156134910"
+    ditto_hgvs_variant_genomic_unit["Ensembl_Transcript_Id"] = "ENST00000368297"
+    ditto_hgvs_variant_genomic_unit["ensembl_vep_vcf_string"] = "1-156134910-C-T"
+
+    annotation_unit = AnnotationUnit(ditto_hgvs_variant_genomic_unit, ditto_score_dataset)
+
+    return annotation_unit
+
+
+@pytest.fixture(name="subprocess_annotation_ditto_score_task")
+def fixture_subprocess_annotation_ditto_score(hgvs_variant_ditto_annotation_unit):
+    """ Creates a subprocess task with the ditto annotation unit fixture """
+
+    task = SubprocessAnnotationTask(hgvs_variant_ditto_annotation_unit)
+
+    return task

--- a/etc/fixtures/initial-seed/annotations-config.json
+++ b/etc/fixtures/initial-seed/annotations-config.json
@@ -758,5 +758,72 @@
     ],
     "version_url": "https://rest.ensembl.org/info/data/?content-type=application/json",
     "version_attribute": ".releases[]"
+  },
+  {
+    "data_set":"chrom",
+    "data_source":"Rosalution",
+    "genomic_unit_type":"hgvs_variant",
+    "annotation_source_type":"forge",
+    "base_string":"{ensembl_vep_vcf_string}",
+    "dependencies": [
+       "ensembl_vep_vcf_string"
+    ],
+    "attribute":".chrom | split(\"-\") | { \"chrom\": .[0] }",
+    "versioning_type":"rosalution"
+ },
+ {
+    "data_set":"pos",
+    "data_source":"Rosalution",
+    "genomic_unit_type":"hgvs_variant",
+    "annotation_source_type":"forge",
+    "base_string":"{ensembl_vep_vcf_string}",
+    "dependencies": [
+       "ensembl_vep_vcf_string"
+    ],
+    "attribute":".pos | split(\"-\") | { \"pos\": .[1] }",
+    "versioning_type":"rosalution"
+  },
+  {
+    "data_set": "transcript_without_version",
+    "data_source": "Rosalution",
+    "annotation_source_type": "forge",
+    "genomic_unit_type": "hgvs_variant",
+    "base_string": "{hgvs_variant_without_transcript_version}",
+    "attribute": ".transcript_without_version | split(\":\") | { \"transcript_without_version\": .[0] }",
+    "dependencies": [
+      "hgvs_variant_without_transcript_version"
+    ],
+    "versioning_type": "rosalution"
+  },
+  {
+    "data_set": "Ensembl_Transcript_Id",
+    "data_source": "Ensembl",
+    "genomic_unit_type": "hgvs_variant",
+    "annotation_source_type": "http",
+    "url": "https://rest.ensembl.org/xrefs/symbol/homo_sapiens/{transcript_without_version}?content-type=application/json;object_type=transcript",
+    "attribute": "{ \"Ensembl_Transcript_Id\": .[0].id }",
+    "dependencies": [
+      "transcript_without_version"
+    ],
+    "versioning_type": "rest",
+    "version_url": "https://rest.ensembl.org/info/data/?content-type=application/json",
+    "version_attribute": ".releases[]"
+  },
+  {
+    "data_set": "DITTO",
+    "data_source": "cgds",
+    "genomic_unit_type": "hgvs_variant",
+    "annotation_source_type": "subprocess",
+    "subprocess": "tabix https://s3.lts.rc.uab.edu/cgds-public/dittodb/DITTO_chr{chrom}.tsv.gz chr{chrom}:{pos}-{pos}",
+    "fieldnames": ["chrom", "pos", "ref", "alt", "transcript", "gene", "classification", "ditto"],
+    "delimiter": "\t",
+    "attribute": ".[] += (\"{ensembl_vep_vcf_string}\" | split(\"-\") | {\"vcf_string\": .}) | .[] | select( .chrom == (\"chr\" + .vcf_string[0]) and .vcf_string[1] == .pos and .vcf_string[2] == .ref and .vcf_string[3] == .alt and .transcript ==\"{Ensembl_Transcript_Id}\") | { \"ditto\": .ditto }",
+    "dependencies": [
+      "chrom",
+      "pos",
+      "Ensembl_Transcript_Id",
+      "ensembl_vep_vcf_string"
+    ],
+    "versioning_type": "rosalution"
   }
 ]


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] New or existing JSON is formatted using JQ

## Pull Request Details

Changes made:

- Added a new Subprocess Annotation Task to programmatically call linux programs and return a result.
- Included Samtools and Tabix in the Dockerfile to allow querying of remote .tsv files
- Updated the `annotation-configs.json` to include the new DITTO subprocess annotations and required dependencies
- New task type is fully tested and linted

**To Review:**
<!-- Make a to do list of things to check for to approve the pull request -->
<!-- Modify the below list as appropriate by editing and deleting text that is not applicable-->

- [ ] Static Analysis by Reviewer
- [ ] Rebuild the local Docker containers for Rosalution and deploy Rosalution
  To check this run the following commands:
  ``` bash
  # From the root of Rosalution
  docker compose down
  docker system prune -a --volumes

  docker compose up --build
  ```
- [ ] Upload a test case from the fixtures and see if DITTO annotates properly
  - Go to [https://local.rosalution.cgds/rosalution](https://local.rosalution.cgds/rosalution)
  - Login with `developer`
  - Click the `Create New Analysis` button
  - Upload the `etc/fixtures/import/C-PAM0042.json` file from Rosalution fixtures
  - When annotations finish, does DITTO display a score?
- [ ] All Github Actions checks have passed.

---

### Screenshots

![Screenshot 2025-02-21 at 3 00 39 PM](https://github.com/user-attachments/assets/1c52af59-eecb-4fad-8546-961e1075fed6)