### PR TITLE
Upgrading jq package to 1.8.0 for jq to work with python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Features
 
+- Discussion Post Threads - Users can collaborate by replying to existing discussion posts in a discussion thread in
+  order to capture insights and have relevant conversations with other experts to make more robust decisions on an
+  analysis in Rosalution. Also includes support to edit and delete replies a user has authored.
 - Caching calls to HTTP datasources configured as a dataset, and forge annotation tasks can be enabled to read value
   from the cached call dataset.
 - Caching versions in-memory temporarily when processing annotations.  A version is cached used its datasource &
@@ -19,6 +22,7 @@
 
 - Updated Python Backend to not use `datetime.utcnow()` which is being deprecated.
 - Revised invalid HTML DOM that mixed `<table>` HTML DOM elements within `<div>`s and `<span>`s.
+- Upgrading jq Python module to 1.8.0 to be to support building the backend for Python 3.13+
 
 ## 0.8.4
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.23.2
 python-cas==1.6.0
 itsdangerous==2.1.2
 pymongo==4.6.3
-jq==1.6.0
+jq==1.8.0
 
 python-multipart==0.0.20
 PyJWT[crypto]==2.8.0


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] New or existing JSON is formatted using JQ
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

<!-- Delete the tasks from the above list that are Not Applicable for your pull request -->

## Pull Request Details

Wrike Ticket - [[Chore] Upgrade jq python module to 1.8.0 for Python 3.13+ support](https://www.wrike.com/open.htm?id=1666690922)

Changes made:

- Upgraded jq Python module to 1.8.0 to build successfully with Python 3.13

**To Review:**

- [x] Static Analysis by Reviewer
- [x] The changes made to the backend with the update `jq` page is working as intended/rendered correctly.
  To check this run the following commands:

  ``` bash
  docker compose down
  docker system prune -a --volumes
  ./setup.sh clean
  ```
  - [x] Import `C-PAM0042.json` from `etc/fixtures/import` and verify that new analysis's annotations successfully processed and are rendering
  - [x] Run Python unit and integration tests with **Python 3.13** locally

- [x] All Github Actions checks have passed.
