### PR TITLE
Updated the annotation task completion to catch HTTPErrors as expecte…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ### Features - In Progress
 
+## 0.8.6
+
+### Bugs
+
+- Catching HTTP Error exceptions from the Python requests module during annotation; Uncaught HTTPError exceptions
+  cause the annotation background task in FastAPI to crash without completing annotations in the queue.
+
 ## 0.8.5
 
 ### Features

--- a/backend/src/core/annotation.py
+++ b/backend/src/core/annotation.py
@@ -3,7 +3,7 @@ import concurrent
 import logging
 import time
 import queue
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import JSONDecodeError, HTTPError
 
 from ..repository.analysis_collection import AnalysisCollection
 from ..repository.genomic_unit_collection import GenomicUnitCollection
@@ -229,7 +229,7 @@ class AnnotationProcess():
             logger.error('%s Exception [%s] Not Found [%s]', format_annotation_logging(annotation_unit), error, task)
             logger.exception(error)
             self.track_dataset_exception(annotation_unit, error)
-        except (JSONDecodeError, TypeError, ValueError) as exception_error:
+        except (JSONDecodeError, TypeError, ValueError, HTTPError) as exception_error:
             logger.error('%s Exception [%s]', format_annotation_logging(annotation_unit), exception_error)
             logger.exception(exception_error)
             self.track_dataset_exception(annotation_unit, exception_error)

--- a/etc/fixtures/import/CPAM0176_PLIN4.json
+++ b/etc/fixtures/import/CPAM0176_PLIN4.json
@@ -1,0 +1,88 @@
+{
+    "date": "2025-08-12T21:21:09.000Z",
+    "external_id": "CPAM0176 (PLIN4) [Unknown Position]",
+    "variants": [
+        {
+            "transcript": "NM_001367868.2",
+            "sanger": "NA",
+            "evidence": [
+                "reported"
+            ],
+            "zygosity": "heterozygous",
+            "gene": "ENSG00000167676",
+            "interpretation": "likely_pathogenic",
+            "reference_genome": "GRCh37",
+            "chromosome": "19",
+            "effect": "repeat_expansion",
+            "inheritance": "paternal",
+            "cdna": "c.(?_?)[37]",
+            "segregation": "segregates"
+        }
+    ],
+    "features": [
+        {
+            "id": "HP:0001265",
+            "label": "Hyporeflexia",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0001324",
+            "label": "Muscle weakness",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0003202",
+            "label": "Skeletal muscle atrophy",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0003236",
+            "label": "Elevated serum creatine kinase",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0003691",
+            "label": "Scapular winging",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0003750",
+            "label": "Increased muscle fatiguability",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0003805",
+            "label": "Rimmed vacuoles",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0009050",
+            "label": "Quadriceps muscle atrophy",
+            "type": "phenotype",
+            "observed": "yes"
+        },
+        {
+            "id": "HP:0012548",
+            "label": "Fatty replacement of skeletal muscle",
+            "type": "phenotype",
+            "observed": "yes"
+        }
+    ],
+    "genes": [
+        {
+            "gene": "PLIN4",
+            "id": "ENSG00000167676",
+            "strategy": [
+                "familial_mutation"
+            ],
+            "status": "candidate"
+        }
+    ]
+}

--- a/etc/fixtures/import/CPAM0176_PLIN4.json
+++ b/etc/fixtures/import/CPAM0176_PLIN4.json
@@ -15,7 +15,7 @@
             "chromosome": "19",
             "effect": "repeat_expansion",
             "inheritance": "paternal",
-            "cdna": "c.(?_?)[37]",
+            "cdna": "c.?_?[37]",
             "segregation": "segregates"
         }
     ],

--- a/frontend/src/models/annotations.js
+++ b/frontend/src/models/annotations.js
@@ -4,7 +4,7 @@ export default {
   async getAnnotations(analysisName, gene, variant) {
     const baseUrl = '/rosalution/api/analysis';
 
-    const variantWithoutProtein = variant.replace(/\(.*/, '');
+    const variantWithEncodedSpecialCharacters = variant.replaceAll('?', '%3F')
 
     /**
      * Inline helper method to determine if the variant annotations need to get queried.
@@ -20,7 +20,7 @@ export default {
 
     const [geneAnnotations, variantAnnotations] = await Promise.all([
       Requests.get(`${baseUrl}/${analysisName}/gene/${gene}`),
-      ...insertIf(variant !== '', Requests.get(`${baseUrl}/${analysisName}/hgvsVariant/${variantWithoutProtein}`)),
+      ...insertIf(variant !== '', Requests.get(`${baseUrl}/${analysisName}/hgvsVariant/${variantWithEncodedSpecialCharacters}`)),
     ]);
     return {...geneAnnotations, ...variantAnnotations};
   },

--- a/frontend/src/models/annotations.js
+++ b/frontend/src/models/annotations.js
@@ -1,10 +1,15 @@
 import Requests from '@/requests.js';
 
+
+function encodeVariantSpecialCharacters(incomingVariant) {
+  return incomingVariant.replaceAll('?', '%3F');
+}
+
 export default {
   async getAnnotations(analysisName, gene, variant) {
     const baseUrl = '/rosalution/api/analysis';
 
-    const variantWithEncodedSpecialCharacters = variant.replaceAll('?', '%3F')
+    const encodedVariantForUrl = encodeVariantSpecialCharacters(variant);
 
     /**
      * Inline helper method to determine if the variant annotations need to get queried.
@@ -20,33 +25,40 @@ export default {
 
     const [geneAnnotations, variantAnnotations] = await Promise.all([
       Requests.get(`${baseUrl}/${analysisName}/gene/${gene}`),
-      ...insertIf(variant !== '', Requests.get(`${baseUrl}/${analysisName}/hgvsVariant/${variantWithEncodedSpecialCharacters}`)),
+      ...insertIf(variant !== '', Requests.get(`${baseUrl}/${analysisName}/hgvsVariant/${encodedVariantForUrl}`)),
     ]);
     return {...geneAnnotations, ...variantAnnotations};
   },
   async attachAnnotationImage(genomicUnit, dataSet, annotation) {
     const baseUrl = `/rosalution/api/annotation`;
 
+    const encodedGenomicUnit =
+      (annotation.genomic_unit_type === 'hgvs_variant') ? encodeVariantSpecialCharacters(genomicUnit) : genomicUnit;
+
+
     const attachmentForm = {
       'upload_file': annotation.annotation_data,
     };
 
-    return await Requests.postForm(
-        `${baseUrl}/${genomicUnit}/${dataSet}/attachment?genomic_unit_type=${annotation.genomic_unit_type}`,
-        attachmentForm,
-    );
+    const url = `${baseUrl}/${encodedGenomicUnit}/${dataSet}` +
+      `/attachment?genomic_unit_type=${annotation.genomic_unit_type}`;
+
+    return await Requests.postForm(url, attachmentForm);
   },
   async updateAnnotationImage(genomicUnit, dataSet, oldId, annotation) {
     const baseUrl = '/rosalution/api/annotation';
 
+    const encodedGenomicUnit =
+      (annotation.genomic_unit_type === 'hgvs_variant') ? encodeVariantSpecialCharacters(genomicUnit) : genomicUnit;
+
     const attachmentForm = {
       'upload_file': annotation.annotation_data,
     };
 
-    return await Requests.putForm(
-        `${baseUrl}/${genomicUnit}/${dataSet}/attachment/${oldId}?genomic_unit_type=${annotation.genomic_unit_type}`,
-        attachmentForm,
-    );
+    const url = `${baseUrl}/${encodedGenomicUnit}/${dataSet}/`+
+      `attachment/${oldId}?genomic_unit_type=${annotation.genomic_unit_type}`;
+
+    return await Requests.putForm(url, attachmentForm);
   },
   async removeAnnotationImage(genomicUnit, dataSet, fileId, annotation) {
     const baseUrl = '/rosalution/api/annotation';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] New or existing JSON is formatted using JQ
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

<!-- Delete the tasks from the above list that are Not Applicable for your pull request -->

## Pull Request Details

Wrike Ticket - [[Investigate] Why a repeat expansion variant with unknown position crashes the annotation background task](https://www.wrike.com/open.htm?id=1728030758)

Changes made:

- After investigating, realized that while the HTTP Error is getting thrown as expected for a datasource not being able to process the type of variant, it was not getting caught and processed as the other exceptions were. Updated the annotation process to catch HTTPError Exceptions from the requests module.

**To Review:**
<!-- Make a to do list of things to check for to approve the pull request -->
<!-- Modify the below list as appropriate by editing and deleting text that is not applicable-->

- [x] Static Analysis by Reviewer
- [x] The change made to annotating a new incoming analysis is working as intended/rendered correctly.
  To check this run the following commands:

  ``` bash
  docker compose down
  docker system prune -a --volumes
  ./setup.sh clean
  ```
  - [x] Import `CPAM0176_PLIN.json` from `etc/fixtures/import` verify 
    - [x] Analysis's annotations successfully processed
    - [x] Annotation page renders for the gene & variant (known issue with the variant not showing it upper drop down menu
    - [x] Attaching an image to the 'chromosomal localization' section for the variant annotation

<img width="2171" height="158" alt="Screenshot 2025-08-13 at 2 33 52 PM" src="https://github.com/user-attachments/assets/7db2a8c5-8b9d-4e44-8c24-7fc575cf058b" />

<img width="1332" height="796" alt="Screenshot 2025-08-13 at 2 39 22 PM" src="https://github.com/user-attachments/assets/7c808c69-b5bb-4f49-886b-858f649a87c5" />

- [x] All Github Actions checks have passed.
