### PR TITLE
Reply button Attachment row Styling Fix

### DIFF
--- a/frontend/src/components/AnalysisView/DiscussionPost.vue
+++ b/frontend/src/components/AnalysisView/DiscussionPost.vue
@@ -61,6 +61,7 @@
             >
             </DiscussionAttachment>
           </div>
+          <div v-else></div>
           <button class="discussion-reply-button" @click="newDiscussionReplyForm"
           data-test="discussion-new-reply-button">
             <font-awesome-icon icon="reply" size="lg"/>
@@ -393,7 +394,7 @@ async function removeReplyAttachment(replyId, attachmentIndex) {
 
 .discussion-attachment-reply-button-row {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 }
 
 .attachments-list {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] New or existing JSON is formatted using JQ
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

<!-- Delete the tasks from the above list that are Not Applicable for your pull request -->

## Pull Request Details

Wrike - [[Bug] Reply button on Discussion Posts be spaced out correctly with Attachments in Post](https://www.wrike.com/open.htm?id=1679373880)

Changes made:

- Fixed the CSS bug to correct reply button/attachments row in Discussion Posts.

**To Review:**
<!-- Make a to do list of things to check for to approve the pull request -->
<!-- Modify the below list as appropriate by editing and deleting text that is not applicable-->

- [ ] Static Analysis by Reviewer
- [ ] The reply button attachment row is aligned are working as intended/rendered correctly.
  To check this run the following commands:

  ``` bash
     docker compose down
     docker system prune -a --volumes
     docker compose up --build -d
  ```
      - Navigate to [](https://local.rosalution.cgds/rosalution/) Login as developer.
      - Click on CPAM0002 case, and navigate to the Analysis View, and then scroll down to the Discussions section.
      - Navigate to the Discussions section and to any of the published Discussion Posts. Make a new post with a new attachment (not from existing attachments).
      - Make sure the attachment and reply button is aligned correctly.
      
- [ ] All Github Actions checks have passed.

<!-- Delete below header if Screenshots are NOT included -->
### Screenshots (if appropriate)

<img width="1773" height="343" alt="Screenshot 2025-08-26 at 12 12 19 PM" src="https://github.com/user-attachments/assets/d10d10eb-878b-4fea-8aa8-def11e75db7b" />

