### PR TITLE
Editing removing omic units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - TextDataset components support enabling a copy text button via the annotation rendering layout configuration.
 - Introduced new keyword in annotation configuration for 'protein' allowing use of an HGVS variant’s p.dot value.
 - Add and annotate new omic units to existing analyses, with a reason of interest.
+    - Reason of interest is editable for manually added variants when an analysis is in 'Edit Mode'. Manually added
+      variants are also removable when an analysis is in 'Edit Mode'.
 
 ## 0.8.8-er
 

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -8,4 +8,5 @@ omit =
        src/models/user.py
        src/models/phenotips_json.py
        src/security/oauth2.py
+       src/profiler_middleware.py
        *__init__.py

--- a/backend/src/repository/analysis_collection.py
+++ b/backend/src/repository/analysis_collection.py
@@ -107,44 +107,89 @@ class AnalysisCollection:
 
         self.collection.find_one_and_update({
             "name": analysis_name, "genomic_units.gene": {"$ne": new_genomic_unit["gene"]}
-        }, {'$addToSet': {"genomic_units": {"gene": new_genomic_unit["gene"], "transcripts": [], "variants": []}}})
-
-        updated_analysis = self.collection.find_one_and_update({
-            "name": analysis_name, "genomic_units.gene": new_genomic_unit["gene"]
         }, {
             '$addToSet': {
-                "genomic_units.$[unit].transcripts": {"transcript": new_genomic_unit["transcript"]},
-                "genomic_units.$[unit].variants": {
-                    "hgvs_variant": new_genomic_unit["transcript"] + ":" + new_genomic_unit["cdna"], "c_dot":
-                        new_genomic_unit["cdna"], "p_dot": new_genomic_unit["protein"], "build": "GRCh38",
-                    "case": [{"field": "Reason of Interest", "value": new_genomic_unit["reason_of_interest"]}]
+                "genomic_units": {"gene": new_genomic_unit["gene"], "transcripts": [], "variants": [], "manual": True}
+            }
+        })
+
+        hgvs_variant = new_genomic_unit["transcript"] + ":" + new_genomic_unit["cdna"]
+        find_filter = {
+            "name": analysis_name,
+        }
+
+        updated_analysis = self.collection.find_one_and_update(
+            find_filter, {
+                '$addToSet': {
+                    "genomic_units.$[unit].transcripts": {"transcript": new_genomic_unit["transcript"]},
+                    "genomic_units.$[unit].variants": {
+                        "hgvs_variant": hgvs_variant, "c_dot": new_genomic_unit["cdna"], "p_dot":
+                            new_genomic_unit["protein"], "build": "GRCh38",
+                        "case": [{"field": "Reason of Interest", "value": new_genomic_unit["reason_of_interest"]}]
+                    }
                 }
+            },
+            array_filters=[{
+                "unit.gene": new_genomic_unit["gene"],
+                "unit.variants": {"$not": {"$elemMatch": {'hgvs_variant': hgvs_variant}}}
+            }],
+            return_document=ReturnDocument.AFTER
+        )
+
+        return updated_analysis
+
+    def edit_genomic_unit_reason_of_interest(
+        self, analysis_name: str, gene: str, hgvs_variant: str, reason_of_interest: list[str]
+    ):
+        """
+        Edits the reason of interest for manually added genomic unit by analysis name, gene, and variant.
+        """
+        updated_analysis = self.collection.find_one_and_update({"name": analysis_name, "genomic_units.gene": gene}, {
+            '$set': {
+                "genomic_units.$[unit].variants.$[variant].case":
+                    [{"field": "Reason of Interest", "value": reason_of_interest}]
             }
         },
-                                                               array_filters=[{"unit.gene": new_genomic_unit["gene"]}],
+                                                               array_filters=[{"unit.gene": gene},
+                                                                              {"variant.hgvs_variant": hgvs_variant}],
                                                                return_document=ReturnDocument.AFTER)
 
         return updated_analysis
 
-    def edit_genomic_unit_reason_of_interest(self, analysis_name: str, gene: str, hgvs_variant: str, reason_of_interest: list[str]):
+    def delete_manual_omic_unit(self, analysis_name: str, gene: str, hgvs_variant: str):
         """
-        Edits the reason of interest for linked genomic unit by analysis name, gene, and variant information.
+        Deletes a manually added omic unit from an analysis. Raises ValueError if the genomic unit is not a
+        manually added unit.
         """
-        updated_analysis = self.collection.find_one_and_update({
-            "name": analysis_name,
-            "genomic_units.gene": gene
-        }, {
-            '$set': {
-                "genomic_units.$[unit].variants.$[variant].case": [{
-                    "field": "Reason of Interest", "value": reason_of_interest
-                }]
+
+        is_manually_added_omic_unit = self.collection.count_documents({
+            "name": analysis_name, "genomic_units": {
+                "$elemMatch": {
+                    "gene": gene,
+                    "variants": {"$elemMatch": {"hgvs_variant": hgvs_variant, "case.field": "Reason of Interest"}}
+                }
             }
-        },
-        array_filters=[
-            {"unit.gene": gene},
-            {"variant.hgvs_variant": hgvs_variant}
-        ],
-        return_document=ReturnDocument.AFTER)
+        })
+
+        if not is_manually_added_omic_unit:
+            raise ValueError(f"{gene} {hgvs_variant} is not a manually added unit within analysis {analysis_name}")
+
+        self.collection.update_one({
+            "name": analysis_name, "genomic_units": {
+                "$elemMatch": {
+                    "gene": gene,
+                    "variants": {"$elemMatch": {"hgvs_variant": hgvs_variant, "case.field": "Reason of Interest"}}
+                }
+            }
+        }, {"$pull": {"genomic_units.$[unit].variants": {"hgvs_variant": hgvs_variant}}},
+                                   array_filters=[{'unit.gene': gene}])
+
+        self.collection.update_one({
+            "name": analysis_name,
+            "genomic_units": {"$elemMatch": {"gene": gene, "manual": True, "variants.0": {"$exists": False}}},
+        }, {"$pull": {"genomic_units": {"gene": gene}}})
+
+        updated_analysis = self.collection.find_one({"name": analysis_name})
 
         return updated_analysis
 

--- a/backend/src/repository/analysis_collection.py
+++ b/backend/src/repository/analysis_collection.py
@@ -97,7 +97,7 @@ class AnalysisCollection:
                 'gene': "JAK2",
                 'cdna': "c.1694G>C",
                 'protein': "p.Arg565Thr",
-                'reason_of_interest': "Find this variant interesting to explore.",
+                'reason_of_interest': ["Find this variant interesting to explore."],
             }
         """
 
@@ -117,7 +117,7 @@ class AnalysisCollection:
                 "genomic_units.$[unit].variants": {
                     "hgvs_variant": new_genomic_unit["transcript"] + ":" + new_genomic_unit["cdna"], "c_dot":
                         new_genomic_unit["cdna"], "p_dot": new_genomic_unit["protein"], "build": "GRCh38",
-                    "case": [{"field": "Reason of Interest", "value": [new_genomic_unit["reason_of_interest"],]}]
+                    "case": [{"field": "Reason of Interest", "value": new_genomic_unit["reason_of_interest"]}]
                 }
             }
         },

--- a/backend/src/repository/analysis_collection.py
+++ b/backend/src/repository/analysis_collection.py
@@ -126,6 +126,28 @@ class AnalysisCollection:
 
         return updated_analysis
 
+    def edit_genomic_unit_reason_of_interest(self, analysis_name: str, gene: str, hgvs_variant: str, reason_of_interest: list[str]):
+        """
+        Edits the reason of interest for linked genomic unit by analysis name, gene, and variant information.
+        """
+        updated_analysis = self.collection.find_one_and_update({
+            "name": analysis_name,
+            "genomic_units.gene": gene
+        }, {
+            '$set': {
+                "genomic_units.$[unit].variants.$[variant].case": [{
+                    "field": "Reason of Interest", "value": reason_of_interest
+                }]
+            }
+        },
+        array_filters=[
+            {"unit.gene": gene},
+            {"variant.hgvs_variant": hgvs_variant}
+        ],
+        return_document=ReturnDocument.AFTER)
+
+        return updated_analysis
+
     def add_dataset_to_manifest(self, analysis_name: str, annotation_unit: AnnotationUnit):
         """Adds this dataset and its version to this Analysis."""
         dataset = {

--- a/backend/src/routers/analysis_omic_unit_router.py
+++ b/backend/src/routers/analysis_omic_unit_router.py
@@ -2,11 +2,11 @@
 
 # pylint: disable=duplicate-code
 
-from fastapi import APIRouter, Depends, Security, BackgroundTasks
+from fastapi import APIRouter, Depends, Security, BackgroundTasks, HTTPException, status
 from pydantic import BaseModel
 
 from ..dependencies import database, annotation_queue
-from ..security.security import get_project_authorization, get_write_project_authorization
+from ..security.security import get_write_project_authorization
 
 from ..models.analysis import Analysis
 from ..core.phenotips_importer import PhenotipsImporter
@@ -23,11 +23,17 @@ class IncomingGenomicUnit(BaseModel):
     protein: str | None = None
     reason_of_interest: list[str]
 
+
 class IncomingEditGenomicUnit(BaseModel):
     """Editing the reason of interest for a genomic unit"""
     reason_of_interest: list[str]
 
-@router.post("/{analysis_name}/genomic_unit", tags=["analysis genomic units"],dependencies=[Security(get_write_project_authorization)])
+
+@router.post(
+    "/{analysis_name}/genomic_unit",
+    tags=["analysis genomic units"],
+    dependencies=[Security(get_write_project_authorization)]
+)
 def add_genomic_units(
     background_tasks: BackgroundTasks,
     analysis_name: str,
@@ -39,10 +45,9 @@ def add_genomic_units(
 
     new_genomic_unit_dict = new_genomic_unit.model_dump()
 
-
     updated_analysis_json = repositories["analysis"].add_genomic_units(analysis_name, new_genomic_unit_dict)
 
-    # Annotating the new genomic unit added in the updated_analysis_json
+    # Default setting the reference build to Build 38 due to Rosalution only supporting build 38 at this time
     new_genomic_unit_dict["reference_genome"] = "GRCh38"
 
     new_genomic_unit_data = PhenotipsImporter.import_genomic_unit_collection_data(new_genomic_unit_dict, "gene")
@@ -51,7 +56,6 @@ def add_genomic_units(
     new_genomic_unit_data = PhenotipsImporter.import_genomic_unit_collection_data(new_genomic_unit_dict, "hgvs")
     repositories["genomic_unit"].create_genomic_unit(new_genomic_unit_data)
 
-    # structuring list for units to annotate
     analysis = Analysis(**updated_analysis_json)
     new_genomic_units_list = []
     for unit in analysis.genomic_units:
@@ -59,7 +63,6 @@ def add_genomic_units(
             new_genomic_units_list.append(unit)
             break
 
-    # Getting units to annotate
     new_genomic_unit_to_annotate = analysis.units_to_annotate(new_genomic_units_list)
 
     # Calling AnnotationService to queue annotation tasks by given unit
@@ -71,9 +74,38 @@ def add_genomic_units(
 
     return updated_analysis_json["genomic_units"]
 
-@router.put("/{analysis_name}/genomic_unit/{gene}/{hgvs_variant}",dependencies=[Security(get_write_project_authorization)])
-def edit_genomic_unit_reason_of_interest(analysis_name: str, gene: str, hgvs_variant: str, edit_unit: IncomingEditGenomicUnit, repositories=Depends(database)):
-    
-    updated_analysis_json = repositories["analysis"].edit_genomic_unit_reason_of_interest(analysis_name, gene, hgvs_variant, edit_unit.reason_of_interest)
+
+@router.put(
+    "/{analysis_name}/genomic_unit/{gene}/{hgvs_variant}", dependencies=[Security(get_write_project_authorization)]
+)
+def edit_genomic_unit_reason_of_interest(
+    analysis_name: str,
+    gene: str,
+    hgvs_variant: str,
+    edit_unit: IncomingEditGenomicUnit,
+    repositories=Depends(database)
+):
+    """Editing the reason of interest for a manually added genomic unit in an analysis"""
+
+    updated_analysis_json = repositories["analysis"].edit_genomic_unit_reason_of_interest(
+        analysis_name, gene, hgvs_variant, edit_unit.reason_of_interest
+    )
+
+    return updated_analysis_json["genomic_units"]
+
+
+@router.delete(
+    "/{analysis_name}/genomic_unit/{gene}/{hgvs_variant}", dependencies=[Security(get_write_project_authorization)]
+)
+def delete_manual_genomic_unit(analysis_name: str, gene: str, hgvs_variant: str, repositories=Depends(database)):
+    """
+    Deleting a manually added genomic unit from an analysis. Returns an HTTP 405 Method Not Allowed if the 
+    genomic unit is an original from the analysis creation.
+    """
+
+    try:
+        updated_analysis_json = repositories["analysis"].delete_manual_omic_unit(analysis_name, gene, hgvs_variant)
+    except ValueError as exception:
+        raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail=str(exception)) from exception
 
     return updated_analysis_json["genomic_units"]

--- a/backend/src/routers/analysis_omic_unit_router.py
+++ b/backend/src/routers/analysis_omic_unit_router.py
@@ -27,14 +27,13 @@ class IncomingEditGenomicUnit(BaseModel):
     """Editing the reason of interest for a genomic unit"""
     reason_of_interest: list[str]
 
-@router.post("/{analysis_name}/genomic_unit", tags=["analysis genomic units"])
+@router.post("/{analysis_name}/genomic_unit", tags=["analysis genomic units"],dependencies=[Security(get_write_project_authorization)])
 def add_genomic_units(
     background_tasks: BackgroundTasks,
     analysis_name: str,
     new_genomic_unit: IncomingGenomicUnit,
     repositories=Depends(database),
-    annotation_task_queue=Depends(annotation_queue),
-    dependencies=[Security(get_project_authorization)]
+    annotation_task_queue=Depends(annotation_queue)
 ):
     """Adding a new genomic unit to an analysis by Analysis Name"""
 
@@ -72,10 +71,9 @@ def add_genomic_units(
 
     return updated_analysis_json["genomic_units"]
 
-@router.put("/{analysis_name}/genomic_unit/{gene}/{variant}",dependencies=[Security(get_write_project_authorization)])
-def edit_genomic_unit_reason_of_interest(analysis_name: str, gene: str, variant: str, edit_unit: IncomingEditGenomicUnit, repositories=Depends(database)):
-    print(analysis_name)
-    print(gene)
-    print(variant)
-    print(edit_unit)
-    print('calling endpoint to edit the omic units reason of interest')
+@router.put("/{analysis_name}/genomic_unit/{gene}/{hgvs_variant}",dependencies=[Security(get_write_project_authorization)])
+def edit_genomic_unit_reason_of_interest(analysis_name: str, gene: str, hgvs_variant: str, edit_unit: IncomingEditGenomicUnit, repositories=Depends(database)):
+    
+    updated_analysis_json = repositories["analysis"].edit_genomic_unit_reason_of_interest(analysis_name, gene, hgvs_variant, edit_unit.reason_of_interest)
+
+    return updated_analysis_json["genomic_units"]

--- a/backend/src/routers/analysis_omic_unit_router.py
+++ b/backend/src/routers/analysis_omic_unit_router.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Security, BackgroundTasks
 from pydantic import BaseModel
 
 from ..dependencies import database, annotation_queue
-from ..security.security import get_authorization
+from ..security.security import get_project_authorization, get_write_project_authorization
 
 from ..models.analysis import Analysis
 from ..core.phenotips_importer import PhenotipsImporter
@@ -21,8 +21,11 @@ class IncomingGenomicUnit(BaseModel):
     transcript: str | None = None
     cdna: str | None = None
     protein: str | None = None
-    reason_of_interest: str
+    reason_of_interest: list[str]
 
+class IncomingEditGenomicUnit(BaseModel):
+    """Editing the reason of interest for a genomic unit"""
+    reason_of_interest: list[str]
 
 @router.post("/{analysis_name}/genomic_unit", tags=["analysis genomic units"])
 def add_genomic_units(
@@ -31,18 +34,12 @@ def add_genomic_units(
     new_genomic_unit: IncomingGenomicUnit,
     repositories=Depends(database),
     annotation_task_queue=Depends(annotation_queue),
-    authorized=Security(get_authorization, scopes=["write"])  #pylint: disable=unused-argument
+    dependencies=[Security(get_project_authorization)]
 ):
     """Adding a new genomic unit to an analysis by Analysis Name"""
 
     new_genomic_unit_dict = new_genomic_unit.model_dump()
-    # new_genomic_unit_dict = {
-    #     'transcript': "NM_004972.3",
-    #     'gene': "JAK2",
-    #     'cdna': "c.1694G>C",
-    #     'protein': "p.Arg565Thr",
-    #     'reason_of_interest': "Find this variant interesting to explore.",
-    # }
+
 
     updated_analysis_json = repositories["analysis"].add_genomic_units(analysis_name, new_genomic_unit_dict)
 
@@ -74,3 +71,11 @@ def add_genomic_units(
     )
 
     return updated_analysis_json["genomic_units"]
+
+@router.put("/{analysis_name}/genomic_unit/{gene}/{variant}",dependencies=[Security(get_write_project_authorization)])
+def edit_genomic_unit_reason_of_interest(analysis_name: str, gene: str, variant: str, edit_unit: IncomingEditGenomicUnit, repositories=Depends(database)):
+    print(analysis_name)
+    print(gene)
+    print(variant)
+    print(edit_unit)
+    print('calling endpoint to edit the omic units reason of interest')

--- a/backend/tests/integration/test_analysis_omic_unit_router.py
+++ b/backend/tests/integration/test_analysis_omic_unit_router.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import json
+from urllib import response
 import pytest
 
 from fastapi import BackgroundTasks
@@ -10,6 +11,7 @@ from fastapi import BackgroundTasks
 from src.core.annotation import AnnotationService
 
 
+@pytest.mark.usefixtures("mock_security_get_project_authorization")
 def test_adding_and_annotating_new_omic_unit_to_analysis( # pylint: disable=too-many-arguments
       client,
       mock_access_token,
@@ -25,7 +27,7 @@ def test_adding_and_annotating_new_omic_unit_to_analysis( # pylint: disable=too-
         'gene': "JAK2",
         'cdna': "c.1694G>C",
         'protein': "p.Arg565Thr",
-        'reason_of_interest': "Find this variant interesting to explore.",
+        'reason_of_interest': ["Find this variant interesting to explore."],
     }
 
     mock_repositories["analysis"].collection.find_one_and_update.return_value = successfully_added_genomic_units
@@ -50,8 +52,69 @@ def test_adding_and_annotating_new_omic_unit_to_analysis( # pylint: disable=too-
     actual_genomic_units = json.loads(response.text)
     assert len(actual_genomic_units) == 2
 
+@pytest.mark.usefixtures("mock_security_get_project_authorization")
+def test_editing_manual_omic_unit_in_analysis(
+      client,
+      mock_access_token,
+      mock_repositories,
+      successfully_added_genomic_units):
+    """Test editing a manually added omic unit in the analysis"""
 
-# Fixtures at the bottom of the file
+    updated_genomic_unit = {
+        'reason_of_interest': ["Unit Was Edited.", "Additional reason added."],
+    }
+
+    mock_repositories["analysis"].collection.find_one_and_update.return_value = successfully_added_genomic_units
+
+    response = client.put(
+        "/analysis/CPAM0002/genomic_unit/JAK2/NM_004972.3:c.1694G>C",
+        headers={"Authorization": "Bearer " + mock_access_token},
+        content=json.dumps(updated_genomic_unit)
+    )
+
+    actual_calls = mock_repositories["analysis"].collection.find_one_and_update.call_args.args
+    assert actual_calls[1]['$set'] == {
+        'genomic_units.$[unit].variants.$[variant].case': [
+            {"field": "Reason of Interest", "value": ["Unit Was Edited.", "Additional reason added."]}
+        ]
+    }
+    assert response.status_code == 200
+    actual_genomic_units = json.loads(response.text)
+    assert len(actual_genomic_units) == 2
+
+@pytest.mark.usefixtures("mock_security_get_project_authorization")
+def test_successfully_deleting_manual_omic_unit_in_analysis(
+      client,
+      mock_access_token,
+      mock_repositories,
+      cpam0002_analysis_json
+    ):
+    """Test deleting a manually added omic unit in the analysis"""
+
+    mock_repositories["analysis"].collection.count_documents.return_value = 1
+    mock_repositories["analysis"].collection.find_one.return_value = cpam0002_analysis_json
+    
+    response = client.delete(
+        "/analysis/CPAM0002/genomic_unit/JAK2/NM_004972.3:c.1694G>C",
+        headers={"Authorization": "Bearer " + mock_access_token},
+    )
+
+    assert mock_repositories["analysis"].collection.update_one.call_count == 2
+
+    assert response.status_code == 200
+
+@pytest.mark.usefixtures("mock_security_get_project_authorization")
+def test_deleting_non_manual_omic_unit_in_analysis(client,mock_access_token,mock_repositories):
+    """Test deleting a non-manually added omic unit in the analysis, which should raise an HTTP 405 Method Not Allowed error"""
+    mock_repositories["analysis"].collection.count_documents.return_value = 0
+    
+    response = client.delete(
+        "/analysis/CPAM0002/genomic_unit/VMA21/NM_001017980.3:c.164G>T",
+        headers={"Authorization": "Bearer " + mock_access_token},
+    )
+
+    assert mock_repositories["analysis"].collection.update_one.call_count == 0
+    assert response.status_code == 405
 
 
 @pytest.fixture(name="successfully_added_genomic_units")

--- a/backend/tests/integration/test_analysis_omic_unit_router.py
+++ b/backend/tests/integration/test_analysis_omic_unit_router.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import json
-from urllib import response
 import pytest
 
 from fastapi import BackgroundTasks
@@ -48,16 +47,15 @@ def test_adding_and_annotating_new_omic_unit_to_analysis( # pylint: disable=too-
             mock_repositories['analysis']
         )
 
-    assert response.status_code == 200
-    actual_genomic_units = json.loads(response.text)
-    assert len(actual_genomic_units) == 2
+        assert response.status_code == 200
+        actual_genomic_units = json.loads(response.text)
+        assert len(actual_genomic_units) == 2
+
 
 @pytest.mark.usefixtures("mock_security_get_project_authorization")
 def test_editing_manual_omic_unit_in_analysis(
-      client,
-      mock_access_token,
-      mock_repositories,
-      successfully_added_genomic_units):
+    client, mock_access_token, mock_repositories, successfully_added_genomic_units
+):
     """Test editing a manually added omic unit in the analysis"""
 
     updated_genomic_unit = {
@@ -74,26 +72,24 @@ def test_editing_manual_omic_unit_in_analysis(
 
     actual_calls = mock_repositories["analysis"].collection.find_one_and_update.call_args.args
     assert actual_calls[1]['$set'] == {
-        'genomic_units.$[unit].variants.$[variant].case': [
-            {"field": "Reason of Interest", "value": ["Unit Was Edited.", "Additional reason added."]}
-        ]
+        'genomic_units.$[unit].variants.$[variant].case': [{
+            "field": "Reason of Interest", "value": ["Unit Was Edited.", "Additional reason added."]
+        }]
     }
     assert response.status_code == 200
     actual_genomic_units = json.loads(response.text)
     assert len(actual_genomic_units) == 2
 
+
 @pytest.mark.usefixtures("mock_security_get_project_authorization")
 def test_successfully_deleting_manual_omic_unit_in_analysis(
-      client,
-      mock_access_token,
-      mock_repositories,
-      cpam0002_analysis_json
-    ):
+    client, mock_access_token, mock_repositories, cpam0002_analysis_json
+):
     """Test deleting a manually added omic unit in the analysis"""
 
     mock_repositories["analysis"].collection.count_documents.return_value = 1
     mock_repositories["analysis"].collection.find_one.return_value = cpam0002_analysis_json
-    
+
     response = client.delete(
         "/analysis/CPAM0002/genomic_unit/JAK2/NM_004972.3:c.1694G>C",
         headers={"Authorization": "Bearer " + mock_access_token},
@@ -103,11 +99,15 @@ def test_successfully_deleting_manual_omic_unit_in_analysis(
 
     assert response.status_code == 200
 
+
 @pytest.mark.usefixtures("mock_security_get_project_authorization")
-def test_deleting_non_manual_omic_unit_in_analysis(client,mock_access_token,mock_repositories):
-    """Test deleting a non-manually added omic unit in the analysis, which should raise an HTTP 405 Method Not Allowed error"""
+def test_deleting_non_manual_omic_unit_in_analysis(client, mock_access_token, mock_repositories):
+    """
+    Test deleting an original unit in the analysis resulting in the response returning a
+    HTTP 405 Method Not Allowed error.
+    """
     mock_repositories["analysis"].collection.count_documents.return_value = 0
-    
+
     response = client.delete(
         "/analysis/CPAM0002/genomic_unit/VMA21/NM_001017980.3:c.164G>T",
         headers={"Authorization": "Bearer " + mock_access_token},

--- a/backend/tests/unit/repository/test_analysis_collection.py
+++ b/backend/tests/unit/repository/test_analysis_collection.py
@@ -485,6 +485,16 @@ def test_remove_attachment(analysis_collection, cpam0002_analysis_json):
     actual = analysis_collection.remove_attachment("CPAM0002", "633afb87fb250a6ea1569555")
     assert actual == expected
 
+def test_delete_omic_unit_fail_when_not_manual(analysis_collection, cpam0002_analysis_json):
+    """Tests that delete_manual_omic_unit raises an error when the omic unit is not manually added"""
+    analysis_collection.collection.count_documents.return_value = 0
+    analysis_collection.collection.find_one.return_value = cpam0002_analysis_json
+
+    try:
+        analysis_collection.delete_manual_omic_unit("CPAM0002", "VMA21", "NM_001017980.3:c.164G>T")
+    except ValueError as error:
+        assert isinstance(error, ValueError)
+        assert str(error) == "VMA21 NM_001017980.3:c.164G>T is not a manually added unit within analysis CPAM0002"
 
 @pytest.fixture(name="analysis_with_no_p_dot")
 def fixture_analysis_with_no_p_dot():

--- a/backend/tests/unit/repository/test_analysis_collection.py
+++ b/backend/tests/unit/repository/test_analysis_collection.py
@@ -485,6 +485,7 @@ def test_remove_attachment(analysis_collection, cpam0002_analysis_json):
     actual = analysis_collection.remove_attachment("CPAM0002", "633afb87fb250a6ea1569555")
     assert actual == expected
 
+
 def test_delete_omic_unit_fail_when_not_manual(analysis_collection, cpam0002_analysis_json):
     """Tests that delete_manual_omic_unit raises an error when the omic unit is not manually added"""
     analysis_collection.collection.count_documents.return_value = 0
@@ -495,6 +496,7 @@ def test_delete_omic_unit_fail_when_not_manual(analysis_collection, cpam0002_ana
     except ValueError as error:
         assert isinstance(error, ValueError)
         assert str(error) == "VMA21 NM_001017980.3:c.164G>T is not a manually added unit within analysis CPAM0002"
+
 
 @pytest.fixture(name="analysis_with_no_p_dot")
 def fixture_analysis_with_no_p_dot():

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -25,7 +25,6 @@ services:
       - MONGODB_HOST=rosalution-db
       - CAS_LOGIN_ENABLE=True
       - PROFILER_ENABLED=True
-      - PROFILER_ENABLED=True
     command: ['./entrypoint-init.sh']
     deploy:
       labels:

--- a/frontend/src/components/AnalysisView/GeneBox.vue
+++ b/frontend/src/components/AnalysisView/GeneBox.vue
@@ -24,37 +24,48 @@
       </div>
       <div class="seperator-gene"></div>
       <div v-for="variant, index in variants" :key="variant">
-        <div class="variant-sub-section"
-          v-if="variant.c_dot && variant.c_dot.length > 0 || variant.p_dot && variant.p_dot.length > 0">
-          <div class="variant-name-line">
-            <router-link class="variant" :to="{
-                name: 'annotation',
-                params: {
-                  analysis_name: this.name,
-                },
-                query: {
-                  gene: this.gene,
-                  variant: getCompleteHgvsVariantName(variant),
-                },
-                state: {
-                  gene: this.gene,
-                  variant: getCompleteHgvsVariantName(variant),
-                },
-              }"
-              :data-test="`variant-route-${index}`"
-            >
-              <font-awesome-icon icon="angles-right" size="sm" />
-              <span class="variant-transcript">{{ variant.hgvs_variant.split(':')[0] }}:</span>
-              <span>{{ variant.c_dot }}</span>
-              <span v-if="variant.p_dot">({{ variant.p_dot }})</span>
-            </router-link>
-            <CopyToClipboard
-              class="copy-icon"
-              :copyText="variant.hgvs_variant"
-              @clipboard-copy="$emit('clipboard-copy', text)"
-              data-test="copy-button"
-            />
-            <span class="genomic-build"> {{ getBuild(variant.build) }} </span>
+        <div class="variant-sub-section" :class="this.edit && this.isEditable? 'editable' : ''"
+          v-if="variant.c_dot && variant.c_dot.length > 0 || variant.p_dot && variant.p_dot.length > 0"
+          :id="`#${this.gene}-variant-${index}`" :data-test="`${this.gene}-variant-${index}`">
+          <div class="variant-name-row">
+            <div class="variant-name-line">
+              <router-link class="variant" :to="{
+                  name: 'annotation',
+                  params: {
+                    analysis_name: this.name,
+                  },
+                  query: {
+                    gene: this.gene,
+                    variant: getCompleteHgvsVariantName(variant),
+                  },
+                  state: {
+                    gene: this.gene,
+                    variant: getCompleteHgvsVariantName(variant),
+                  },
+                }"
+                :data-test="`variant-route-${index}`"
+              >
+                <font-awesome-icon icon="angles-right" size="sm" />
+                <span class="variant-transcript">{{ variant.hgvs_variant.split(':')[0] }}:</span>
+                <span>{{ variant.c_dot }}</span>
+                <span v-if="variant.p_dot">({{ variant.p_dot }})</span>
+              </router-link>
+              <CopyToClipboard
+                class="copy-icon"
+                :copyText="variant.hgvs_variant"
+                @clipboard-copy="$emit('clipboard-copy', text)"
+                data-test="copy-button"
+              />
+              <span class="genomic-build"> {{ getBuild(variant.build) }} </span>
+            </div>
+            <div v-if="this.edit && this.isEditable">
+                <button class="icon-button attachment-action" data-test="edit-button" @click="$emit('edit-omic-unit', this.gene, variant)">
+                  <font-awesome-icon icon="pencil" size="lg"/>
+                </button>
+                <button class="icon-button attachment-action" data-test="delete-button">
+                  <font-awesome-icon icon="xmark" size="lg"/>
+                </button>
+              </div>
           </div>
           <div class="seperator-variant"></div>
           <div class="variant-case-information">
@@ -78,7 +89,7 @@ import CopyToClipboard from '@/components/CopyToClipboard.vue';
 
 export default {
   name: 'gene-box',
-  emits: ['clipboard-copy'],
+  emits: ['clipboard-copy', 'edit-omic-unit'],
   components: {
     CopyToClipboard,
   },
@@ -95,6 +106,14 @@ export default {
     variants: {
       type: Array,
     },
+    edit: {
+      default: false
+    }
+  },
+  computed: {
+    isEditable() {
+      return this.variants?.some((variant) => variant.case?.some((data) => data.field == "Reason of Interest"))
+    }
   },
   methods: {
     getBuild(build) {
@@ -136,11 +155,16 @@ export default {
   margin-top: var(--p-10);
 }
 
+.variant-name-row {
+  display:flex;
+}
+
 .variant-name-line {
   display: inline-flex;
   align-items: center;
   padding: var(--p-05);
   gap: var(--p-5);
+  flex-grow: 1;
 }
 
 .variant {
@@ -167,7 +191,6 @@ export default {
   border: solid var(--p-005) var(--rosalution-grey-200);
 }
 
-
 .variant-case-information {
   display: flex;
   gap: var(--p-16);
@@ -177,5 +200,12 @@ export default {
 
 .case-field {
   font-weight: 600;
+}
+
+.editable {
+  background: var(--rosalution-grey-50);
+  padding-top: var(--p-5);
+  padding-bottom: var(--p-5);
+  border-radius: var(--content-border-radius);
 }
 </style>

--- a/frontend/src/components/AnalysisView/GeneBox.vue
+++ b/frontend/src/components/AnalysisView/GeneBox.vue
@@ -1,82 +1,82 @@
 <template>
   <div class="rosalution-section-container">
-    <div>
-      <div class="gene-box-header">
-        <router-link class="gene-link" :to="{
-            name: 'annotation',
-            params: {
-              analysis_name: this.name,
-            },
-            query: {
-              gene: this.gene,
-              ...(variants.length > 0 ? { variant: getCompleteHgvsVariantName(variants[0]) } : {}),
-            },
-            state: {
-              gene: this.gene,
-              ...(variants.length > 0 ? { variant: getCompleteHgvsVariantName(variants[0]) } : {}),
-            }
-          }"
-          data-test="gene-route"
-        >
-          <font-awesome-icon icon="angles-right" size="sm" />
-          <h2 data-test="gene-name"> {{ gene }} </h2>
-        </router-link>
-      </div>
-      <div class="seperator-gene"></div>
-      <div v-for="variant, index in variants" :key="variant">
-        <div class="variant-sub-section" :class="this.edit && this.isEditable? 'editable' : ''"
-          v-if="variant.c_dot && variant.c_dot.length > 0 || variant.p_dot && variant.p_dot.length > 0"
-          :id="`#${this.gene}-variant-${index}`" :data-test="`${this.gene}-variant-${index}`">
-          <div class="variant-name-row">
-            <div class="variant-name-line">
-              <router-link class="variant" :to="{
-                  name: 'annotation',
-                  params: {
-                    analysis_name: this.name,
-                  },
-                  query: {
-                    gene: this.gene,
-                    variant: getCompleteHgvsVariantName(variant),
-                  },
-                  state: {
-                    gene: this.gene,
-                    variant: getCompleteHgvsVariantName(variant),
-                  },
-                }"
-                :data-test="`variant-route-${index}`"
-              >
-                <font-awesome-icon icon="angles-right" size="sm" />
-                <span class="variant-transcript">{{ variant.hgvs_variant.split(':')[0] }}:</span>
-                <span>{{ variant.c_dot }}</span>
-                <span v-if="variant.p_dot">({{ variant.p_dot }})</span>
-              </router-link>
-              <CopyToClipboard
-                class="copy-icon"
-                :copyText="variant.hgvs_variant"
-                @clipboard-copy="$emit('clipboard-copy', text)"
-                data-test="copy-button"
-              />
-              <span class="genomic-build"> {{ getBuild(variant.build) }} </span>
-            </div>
-            <div v-if="this.edit && this.isEditable">
-                <button class="icon-button attachment-action" data-test="edit-button" @click="$emit('edit-omic-unit', this.gene, variant)">
-                  <font-awesome-icon icon="pencil" size="lg"/>
-                </button>
-                <button class="icon-button attachment-action" data-test="delete-button">
-                  <font-awesome-icon icon="xmark" size="lg"/>
-                </button>
-              </div>
+    <div class="gene-box-header">
+      <router-link class="gene-link" :to="{
+          name: 'annotation',
+          params: {
+            analysis_name: this.name,
+          },
+          query: {
+            gene: this.gene,
+            ...(variants.length > 0 ? { variant: getCompleteHgvsVariantName(variants[0]) } : {}),
+          },
+          state: {
+            gene: this.gene,
+            ...(variants.length > 0 ? { variant: getCompleteHgvsVariantName(variants[0]) } : {}),
+          }
+        }"
+        data-test="gene-route"
+      >
+        <font-awesome-icon icon="angles-right" size="sm" />
+        <h2 data-test="gene-name"> {{ gene }} </h2>
+      </router-link>
+    </div>
+    <div class="seperator-gene"></div>
+    <div v-for="variant, index in variants" :key="variant">
+      <div class="variant-sub-section" :class="this.edit && this.isVariantEditable(variant)? 'editable' : ''"
+        v-if="variant.c_dot && variant.c_dot.length > 0 || variant.p_dot && variant.p_dot.length > 0"
+        :id="`#${this.gene}-variant-${index}`" :data-test="`${this.gene}-variant-${index}`">
+        <div class="variant-name-row">
+          <div class="variant-name-line">
+            <router-link class="variant" :to="{
+                name: 'annotation',
+                params: {
+                  analysis_name: this.name,
+                },
+                query: {
+                  gene: this.gene,
+                  variant: getCompleteHgvsVariantName(variant),
+                },
+                state: {
+                  gene: this.gene,
+                  variant: getCompleteHgvsVariantName(variant),
+                },
+              }"
+              :data-test="`variant-route-${index}`"
+            >
+              <font-awesome-icon icon="angles-right" size="sm" />
+              <span class="variant-transcript">{{ variant.hgvs_variant.split(':')[0] }}:</span>
+              <span>{{ variant.c_dot }}</span>
+              <span v-if="variant.p_dot">({{ variant.p_dot }})</span>
+            </router-link>
+            <CopyToClipboard
+              class="copy-icon"
+              :copyText="variant.hgvs_variant"
+              @clipboard-copy="$emit('clipboard-copy', text)"
+              data-test="copy-button"
+            />
+            <span class="genomic-build"> {{ getBuild(variant.build) }} </span>
           </div>
-          <div class="seperator-variant"></div>
-          <div class="variant-case-information">
-            <div v-for="caseInfo in variant.case" :key="caseInfo">
-              <span class="case-field">
-                {{ caseInfo.field }}:
-              </span>
-              <span v-if="caseInfo.value.length > 0">
-                {{ caseInfo.value.join(', ') }}
-              </span>
-            </div>
+          <div v-if="this.edit && this.isVariantEditable(variant)">
+            <button class="icon-button" data-test="edit-button" @click="$emit('edit-omic-unit', this.gene, variant)">
+              <font-awesome-icon icon="pencil" size="lg"/>
+            </button>
+            <button class="icon-button" data-test="delete-button"
+              @click="$emit('delete-omic-unit', this.gene, variant)"
+            >
+              <font-awesome-icon icon="xmark" size="lg"/>
+            </button>
+          </div>
+        </div>
+        <div class="seperator-variant"></div>
+        <div class="variant-case-information">
+          <div v-for="caseInfo in variant.case" :key="caseInfo">
+            <span class="case-field">
+              {{ caseInfo.field }}:
+            </span>
+            <span v-if="caseInfo.value.length > 0">
+              {{ caseInfo.value.join(', ') }}
+            </span>
           </div>
         </div>
       </div>
@@ -89,7 +89,7 @@ import CopyToClipboard from '@/components/CopyToClipboard.vue';
 
 export default {
   name: 'gene-box',
-  emits: ['clipboard-copy', 'edit-omic-unit'],
+  emits: ['clipboard-copy', 'edit-omic-unit', 'delete-omic-unit'],
   components: {
     CopyToClipboard,
   },
@@ -107,15 +107,13 @@ export default {
       type: Array,
     },
     edit: {
-      default: false
-    }
-  },
-  computed: {
-    isEditable() {
-      return this.variants?.some((variant) => variant.case?.some((data) => data.field == "Reason of Interest"))
-    }
+      default: false,
+    },
   },
   methods: {
+    isVariantEditable(variant) {
+      return variant.case?.some((data) => data.field == 'Reason of Interest');
+    },
     getBuild(build) {
       if (build == 'hg19') {
         return 'grch37';

--- a/frontend/src/components/Dialogs/InputDialogOmicUnit.vue
+++ b/frontend/src/components/Dialogs/InputDialogOmicUnit.vue
@@ -80,12 +80,11 @@ const props = defineProps({
 
 const isEditing = props.userInput.edit !== undefined;
 
-console.log(props.userInput)
 const emit = defineEmits(['update:userInput']);
 
 const omicUnit = ref({
   refSeqTranscript: props.userInput.data['refSeqTranscript'],
-  geneSymbol:  props.userInput.data['geneSymbol'],
+  geneSymbol: props.userInput.data['geneSymbol'],
   cdna: props.userInput.data['cdna'],
   protein: props.userInput.data['protein'],
   ROI: props.userInput.data['ROI'],
@@ -141,17 +140,11 @@ const ROI = computed({
   },
 });
 
-const editingOmicUnit = computed({
-
-});
-
 function omicUnitUpdated() {
   const input = props.userInput;
   input['data'] = omicUnit.value;
   emit('update:userInput', toRaw(input));
 }
-
-
 </script>
 
 <style scoped>

--- a/frontend/src/components/Dialogs/InputDialogOmicUnit.vue
+++ b/frontend/src/components/Dialogs/InputDialogOmicUnit.vue
@@ -8,6 +8,8 @@
         class="input-area"
         placeholder="Enter Transcript"
         v-model="refSeqTranscript"
+        data-test="refseq-transcript-input"
+        :readonly="isEditing"
       />
     </div>
     <div class="input-row">
@@ -18,6 +20,8 @@
         class="input-area"
         placeholder="Enter Gene Symbol"
         v-model="geneSymbol"
+        data-test="gene-symbol-input"
+        :readonly="isEditing"
       />
     </div>
     <div class="input-row">
@@ -28,6 +32,8 @@
         class="input-area"
         placeholder="Enter cDNA"
         v-model="cdna"
+        data-test="hgvs-cdna-input"
+        :readonly="isEditing"
       />
     </div>
     <div class="input-row">
@@ -38,24 +44,28 @@
         class="input-area"
         placeholder="Enter Protein"
         v-model="protein"
+        data-test="hgvs-protein-input"
+        :readonly="isEditing"
       />
     </div>
     <div class="input-row">
       <span class="input-field">
         Reason of Interest
       </span>
-      <textarea
+      <MultilineEditableTextarea
         class="input-area"
         placeholder="Enter Reason of Interest."
-        v-model="ROI"
-      >
-      </textarea>
+        v-model:content="ROI"
+        data-test="reason-of-interest-input"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
 import {ref, toRaw, computed} from 'vue';
+
+import MultilineEditableTextarea from '@/components/AnalysisView/MultilineEditableTextarea.vue';
 
 defineOptions({
   name: 'input-dialog-omic-unit',
@@ -68,14 +78,17 @@ const props = defineProps({
   },
 });
 
+const isEditing = props.userInput.edit !== undefined;
+
+console.log(props.userInput)
 const emit = defineEmits(['update:userInput']);
 
 const omicUnit = ref({
-  refSeqTranscript: '',
-  geneSymbol: '',
-  cdna: '',
-  protein: '',
-  ROI: '',
+  refSeqTranscript: props.userInput.data['refSeqTranscript'],
+  geneSymbol:  props.userInput.data['geneSymbol'],
+  cdna: props.userInput.data['cdna'],
+  protein: props.userInput.data['protein'],
+  ROI: props.userInput.data['ROI'],
 });
 
 const refSeqTranscript = computed({
@@ -126,6 +139,10 @@ const ROI = computed({
     omicUnit.value['ROI'] = value;
     omicUnitUpdated();
   },
+});
+
+const editingOmicUnit = computed({
+
 });
 
 function omicUnitUpdated() {

--- a/frontend/src/inputDialog.js
+++ b/frontend/src/inputDialog.js
@@ -119,7 +119,7 @@ export default {
           geneSymbol: '',
           cdna: '',
           protein: '',
-          ROI: '',
+          ROI: [''],
         },
         type: 'omicUnit',
       },
@@ -139,6 +139,27 @@ export default {
     };
     state.tabs.push(attachUrlInput);
     state.activeTabName = attachUrlInput.name;
+    return this;
+  },
+  editOmicUnit(analysisName, omicUnit) {
+    const omicUnitInput = {
+      name: 'input-dialog-omic-unit',
+      icon: 'dna',
+      analysis: analysisName,
+      input: {
+        data: {
+          refSeqTranscript: omicUnit['refSeqTranscript'],
+          geneSymbol: omicUnit['geneSymbol'],
+          cdna: omicUnit['cdna'],
+          protein: omicUnit['protein'],
+          ROI: omicUnit['ROI'],
+        },
+        type: 'omicUnit',
+        edit: true,
+      },
+    };
+    state.tabs.push(omicUnitInput);
+    state.activeTabName = omicUnitInput.name;
     return this;
   },
   prompt() {

--- a/frontend/src/models/analyses.js
+++ b/frontend/src/models/analyses.js
@@ -52,6 +52,18 @@ export default {
     return await Requests.post(url, newOmicUnit);
   },
 
+  async editOmicUnit(analysisName, omicUnit) {
+    const gene = omicUnit.data['geneSymbol'];
+    const variant = `${omicUnit.data['refSeqTranscript']}:${omicUnit.data['cdna']}`
+    const url = `/rosalution/api/analysis/${analysisName}/genomic_unit/${gene}/${variant}`;
+
+    const editOmicUnit = {
+      'reason_of_interest': omicUnit.data['ROI'],
+    };
+
+    return await Requests.put(url, editOmicUnit);
+  },
+
   async pushAnalysisEvent(analysisName, eventType) {
     const url = `/rosalution/api/analysis/${analysisName}/event/${eventType}`;
     return await Requests.put(url);

--- a/frontend/src/models/analyses.js
+++ b/frontend/src/models/analyses.js
@@ -54,7 +54,7 @@ export default {
 
   async editOmicUnit(analysisName, omicUnit) {
     const gene = omicUnit.data['geneSymbol'];
-    const variant = `${omicUnit.data['refSeqTranscript']}:${omicUnit.data['cdna']}`
+    const variant = `${omicUnit.data['refSeqTranscript']}:${omicUnit.data['cdna']}`;
     const url = `/rosalution/api/analysis/${analysisName}/genomic_unit/${gene}/${variant}`;
 
     const editOmicUnit = {
@@ -62,6 +62,14 @@ export default {
     };
 
     return await Requests.put(url, editOmicUnit);
+  },
+
+  async deleteOmicUnit(analysisName, omicUnit) {
+    const gene = omicUnit['geneSymbol'];
+    const variant = `${omicUnit['refSeqTranscript']}:${omicUnit['cdna']}`;
+    const url = `/rosalution/api/analysis/${analysisName}/genomic_unit/${gene}/${variant}`;
+
+    return await Requests.delete(url);
   },
 
   async pushAnalysisEvent(analysisName, eventType) {

--- a/frontend/src/stores/analysisStore.js
+++ b/frontend/src/stores/analysisStore.js
@@ -249,6 +249,14 @@ export const analysisStore = reactive({
     this.analysis.genomic_units = genomicUnits;
   },
 
+async editOmicUnit(omicUnit) {
+  const genomicUnits = await Analyses.editOmicUnit(
+      this.analysisName(),
+      omicUnit,
+  );
+  // this.analysis.genomic_units = genomicUnits;
+},
+
   // -----------------------------------
   // Analysis Operations
   // -----------------------------------

--- a/frontend/src/stores/analysisStore.js
+++ b/frontend/src/stores/analysisStore.js
@@ -254,7 +254,7 @@ async editOmicUnit(omicUnit) {
       this.analysisName(),
       omicUnit,
   );
-  // this.analysis.genomic_units = genomicUnits;
+  this.analysis.genomic_units = genomicUnits;
 },
 
   // -----------------------------------

--- a/frontend/src/stores/analysisStore.js
+++ b/frontend/src/stores/analysisStore.js
@@ -249,14 +249,22 @@ export const analysisStore = reactive({
     this.analysis.genomic_units = genomicUnits;
   },
 
-async editOmicUnit(omicUnit) {
-  const genomicUnits = await Analyses.editOmicUnit(
-      this.analysisName(),
-      omicUnit,
-  );
-  this.analysis.genomic_units = genomicUnits;
-},
+  async editOmicUnit(omicUnit) {
+    const genomicUnits = await Analyses.editOmicUnit(
+        this.analysisName(),
+        omicUnit,
+    );
+    this.analysis.genomic_units = genomicUnits;
+  },
 
+  async deleteOmicUnit(omicUnit) {
+    const genomicUnits = await Analyses.deleteOmicUnit(
+        this.analysisName(),
+        omicUnit,
+    );
+
+    this.analysis.genomic_units = genomicUnits;
+  },
   // -----------------------------------
   // Analysis Operations
   // -----------------------------------

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -115,6 +115,18 @@ select {
   appearance: none;
 }
 
+input:read-only,
+textarea:read-only {
+  background-color: var(--rosalution-grey-100);
+  user-select: all;
+  border: unset;
+}
+
+input:read-only:hover,
+textarea:read-only:hover {
+  box-shadow:  0px 0 0 4px rgba(69, 28, 137, 0.10);
+}
+
 select {
   border-radius: var(--content-border-radius);
   padding: var(--p-5);

--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -21,7 +21,9 @@
         :gene="genomicUnit.gene"
         :transcripts="genomicUnit.transcripts"
         :variants="genomicUnit.variants"
+        :edit="edit"
         @clipboard-copy="copyToClipboard"
+        @edit-omic-unit="editOmicUnit"
       />
       <SectionBox
         v-for="(section) in sectionsList"
@@ -516,6 +518,36 @@ async function addOmicUnit() {
   }
 }
 
+async function editOmicUnit(gene, variant) {
+  console.log(gene)
+  console.log(variant)
+  console.log('omic unit above')
+
+  const omicUnitData = {
+    refSeqTranscript: variant.hgvs_variant.split(":")[0],
+    geneSymbol: gene,
+    cdna: variant.c_dot,
+    protein: variant.p_dot,
+    ROI: variant.case.find(item => item.field === "Reason of Interest")['value']
+  }
+
+  const omicUnit = await inputDialog
+    .confirmText('Edit')
+    .cancelText('Cancel')
+    .message('Please edit reason of interest for' + analysisName.value)
+    .editOmicUnit(analysisName, omicUnitData)
+    .prompt();
+
+  if (!omicUnit) {
+    return;
+  }
+
+  try {
+    await analysisStore.editOmicUnit(omicUnit);
+  } catch (error) {
+    await notificationDialog.title('Failure').confirmText('Ok').alert(error);
+  }
+}
 /**
  * Attaches Monday 3rd Party linkout for C-PAM Case management
  */

--- a/frontend/src/views/AnalysisView.vue
+++ b/frontend/src/views/AnalysisView.vue
@@ -24,6 +24,7 @@
         :edit="edit"
         @clipboard-copy="copyToClipboard"
         @edit-omic-unit="editOmicUnit"
+        @delete-omic-unit="deleteOmicUnit"
       />
       <SectionBox
         v-for="(section) in sectionsList"
@@ -519,24 +520,20 @@ async function addOmicUnit() {
 }
 
 async function editOmicUnit(gene, variant) {
-  console.log(gene)
-  console.log(variant)
-  console.log('omic unit above')
-
   const omicUnitData = {
-    refSeqTranscript: variant.hgvs_variant.split(":")[0],
+    refSeqTranscript: variant.hgvs_variant.split(':')[0],
     geneSymbol: gene,
     cdna: variant.c_dot,
     protein: variant.p_dot,
-    ROI: variant.case.find(item => item.field === "Reason of Interest")['value']
-  }
+    ROI: variant.case.find((item) => item.field === 'Reason of Interest')['value'],
+  };
 
   const omicUnit = await inputDialog
-    .confirmText('Edit')
-    .cancelText('Cancel')
-    .message('Please edit reason of interest for' + analysisName.value)
-    .editOmicUnit(analysisName, omicUnitData)
-    .prompt();
+      .confirmText('Edit')
+      .cancelText('Cancel')
+      .message('Please edit reason of interest for' + analysisName.value)
+      .editOmicUnit(analysisName, omicUnitData)
+      .prompt();
 
   if (!omicUnit) {
     return;
@@ -548,6 +545,36 @@ async function editOmicUnit(gene, variant) {
     await notificationDialog.title('Failure').confirmText('Ok').alert(error);
   }
 }
+
+/**
+ * Delete the linked omic unit from the analysis.
+ */
+async function deleteOmicUnit(gene, variant) {
+  const protein = variant?.p_dot ? ` (${variant?.p_dot})` : '';
+  const variantText = `${gene} ${variant.hgvs_variant}${protein}`;
+  const confirmedDelete = await notificationDialog
+      .title(`Delete Linked Unit`)
+      .confirmText('Delete')
+      .cancelText('Cancel')
+      .confirm(`Are you sure you want to delete ${variantText} from this analysis?`);
+  if (!confirmedDelete) {
+    return;
+  }
+
+  const omicUnit = {
+    refSeqTranscript: variant.hgvs_variant.split(':')[0],
+    geneSymbol: gene,
+    cdna: variant.c_dot,
+    protein: variant.p_dot,
+  };
+
+  try {
+    await analysisStore.deleteOmicUnit(omicUnit);
+  } catch (error) {
+    await notificationDialog.title('Failure').confirmText('Ok').alert(error);
+  }
+}
+
 /**
  * Attaches Monday 3rd Party linkout for C-PAM Case management
  */

--- a/frontend/test/components/Dialogs/InputDialog.spec.js
+++ b/frontend/test/components/Dialogs/InputDialog.spec.js
@@ -4,6 +4,7 @@ import {shallowMount} from '@vue/test-utils';
 import InputDialog from '@/components/Dialogs/InputDialog.vue';
 import InputDialogAttachUrl from '@/components/Dialogs/InputDialogAttachUrl.vue';
 import InputDialogUploadFile from '@/components/Dialogs/InputDialogUploadFile.vue';
+import InputDialogOmicUnit from '@/components/Dialogs/InputDialogOmicUnit.vue';
 
 import inputDialog from '@/inputDialog.js';
 
@@ -23,7 +24,7 @@ describe('InputDialog.vue', () => {
     });
   });
 
-  describe('when prompting to input a URL and File', () => {
+  describe('when prompting and interacting with dialog actions', () => {
     beforeEach(() => {
       const includeComments = true;
       const includeName = true;
@@ -66,25 +67,6 @@ describe('InputDialog.vue', () => {
       confirmButton.trigger('click');
     });
 
-    it('Should show the attach url tab when clicking on the link tab', async () => {
-      await wrapper.find('[data-test=button-input-dialog-attach-url]').trigger('click');
-      const attachUrlComponent = wrapper.findComponent(InputDialogAttachUrl);
-      expect(attachUrlComponent.exists()).to.be.true;
-    });
-
-    it('Should show the upload file tab when clicking the file tab', async () => {
-      await wrapper.find('[data-test=button-input-dialog-upload-file]').trigger('click');
-      const uploadFileComponent = wrapper.findComponent(InputDialogUploadFile);
-      expect(uploadFileComponent.exists()).to.be.true;
-    });
-
-    it('Should show the rosalution existing attachment tab when clicking the Rosalution tab', async () => {
-      const inputDialogRosalutionTab = wrapper.find('[data-test=button-input-dialog-existing-attachments]');
-      await inputDialogRosalutionTab.trigger('click');
-      const existingAttachmentsComponent = wrapper.findComponent(InputDialogExistingAttachments);
-      expect(existingAttachmentsComponent.exists()).to.be.true;
-    });
-
     it('Should show the warning message when one is set', async () => {
       const warningMessageElement = wrapper.find('[data-test=warning-message]');
       expect(warningMessageElement.exists()).to.be.true;
@@ -107,6 +89,55 @@ describe('InputDialog.vue', () => {
       expect(warningMessageElement.exists()).to.be.true;
       expect(warningMessageElement.text()).to.equal('Bolded Text');
       expect(warningMessageElement.html()).to.contain('<b>Bolded Text</b>');
+    });
+  });
+
+  describe('when prompting to input a URL and File', () => {
+    beforeEach(() => {
+      const includeComments = true;
+      const includeName = true;
+
+      inputDialog
+          .confirmText('Add')
+          .cancelText('Cancel')
+          .file(includeComments, 'file', '.pdf, .jpg, .jpeg, .png, .gb')
+          .url(includeComments, includeName)
+          .existing()
+          .message('Warning message')
+          .prompt();
+    });
+    it('Should show the attach url tab when clicking on the link tab', async () => {
+      await wrapper.find('[data-test=button-input-dialog-attach-url]').trigger('click');
+      const attachUrlComponent = wrapper.findComponent(InputDialogAttachUrl);
+      expect(attachUrlComponent.exists()).to.be.true;
+    });
+
+    it('Should show the upload file tab when clicking the file tab', async () => {
+      await wrapper.find('[data-test=button-input-dialog-upload-file]').trigger('click');
+      const uploadFileComponent = wrapper.findComponent(InputDialogUploadFile);
+      expect(uploadFileComponent.exists()).to.be.true;
+    });
+
+    it('Should show the rosalution existing attachment tab when clicking the Rosalution tab', async () => {
+      const inputDialogRosalutionTab = wrapper.find('[data-test=button-input-dialog-existing-attachments]');
+      await inputDialogRosalutionTab.trigger('click');
+      const existingAttachmentsComponent = wrapper.findComponent(InputDialogExistingAttachments);
+      expect(existingAttachmentsComponent.exists()).to.be.true;
+    });
+  });
+
+  describe('when prompting to manually add a variant', () => {
+    beforeEach(() => {
+      inputDialog
+          .confirmText('Add')
+          .cancelText('Cancel')
+          .message('Please enter unti of interest for CPAM0002')
+          .omicUnit('CPAM0002')
+          .prompt();
+    });
+    it('Should show the add omic unit tab', async () => {
+      const omicunitComponent = wrapper.findComponent(InputDialogOmicUnit);
+      expect(omicunitComponent.exists()).to.be.true;
     });
   });
 });

--- a/system-tests/e2e/add_analysis_omic_unit.cy.js
+++ b/system-tests/e2e/add_analysis_omic_unit.cy.js
@@ -10,66 +10,173 @@
     cy.get('[data-test="user-menu"]')
         .find('.grey-rounded-menu')
         .invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;')
-        .as('openActionMenu')
+        .as('openActionMenu');
 
-    // Adding First Linked Omic Unit
-    cy.get('@openActionMenu').within(() => { cy.contains('Add Unit').click() }).invoke('hide');
+    // Adding First Manual Omic Unit
+    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').invoke('hide');
 
-    cy.get('[data-test="gene-symbol-input"]').type('G6PD')
-    cy.get('[data-test="refseq-transcript-input"]').type('NM_001360016.2')
-    cy.get('[data-test="hgvs-cdna-input"]').type('c.563C>T')
-    cy.get('[data-test="hgvs-protein-input"]').type('p.Ser188Phe')
-    cy.get('[data-test="reason-of-interest-input"]').type('Interested in manually adding new omic unit')
-    
+    cy.get('[data-test="gene-symbol-input"]').type('G6PD');
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_001360016.2');
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.563C>T');
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Ser188Phe');
+    cy.get('[data-test="reason-of-interest-input"]').type('Interested in manually adding new omic unit');
+
     cy.get('.primary-button').contains('Add').click();
     cy.get('[data-test="header-title-text"]').click();
 
-    cy.get('[data-test="G6PD-variant-0"]').as('variantRowG6PD')
-    
+    cy.get('[data-test="G6PD-variant-0"]').as('variantRowG6PD');
+
     cy.get('@variantRowG6PD').find('.variant-name-row > .variant-name-line')
-        .should('have.text', 'NM_001360016.2:c.563C>T(p.Ser188Phe)')
+        .should('have.text', 'NM_001360016.2:c.563C>T(p.Ser188Phe)');
 
-    // // Editing First Linked Omic Unit, Must enable Edit Mode to Make omic unit editable
-    cy.get('@openActionMenu').within(() => { cy.contains('Edit').click() }).invoke('hide');
+    // Editing First Manual Omic Unit, Must enable Edit Mode to Make omic unit editable
+    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').invoke('hide'); ;
 
     cy.get('@variantRowG6PD').should('have.class', 'editable');
     cy.get('@variantRowG6PD').find('[data-test="edit-button"]').click();
-    cy.get('[data-test="reason-of-interest-input"]').clear().type('Editing the omic unit of interest')
+    cy.get('[data-test="reason-of-interest-input"]').clear();
+    cy.get('[data-test="reason-of-interest-input"]').type('Editing the omic unit of interest');
     cy.get('.primary-button').contains('Edit').click();
 
     cy.get('@variantRowG6PD').find('.variant-case-information')
-        .should('contain.text', 'Editing the omic unit of interest')
+        .should('contain.text', 'Editing the omic unit of interest');
 
-    // // Adding Second Linked Omic Unit
-    cy.get('@openActionMenu').within(() => { cy.contains('Add Unit').click() }).invoke('hide');
+    // Making sure the system will not add an existing variant
+    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').invoke('hide');
 
-    cy.get('[data-test="gene-symbol-input"]').type('JAK2')
-    cy.get('[data-test="refseq-transcript-input"]').type('NM_004972.3')
-    cy.get('[data-test="hgvs-cdna-input"]').type('c.1694G>C')
-    cy.get('[data-test="hgvs-protein-input"]').type('p.Arg565Thr')
-    cy.get('[data-test="reason-of-interest-input"]').type('Second linked omic unit to this other gene')
+    cy.get('[data-test="gene-symbol-input"]').type('G6PD');
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_001360016.2');
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.563C>T');
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Ser188Phe');
+    cy.get('[data-test="reason-of-interest-input"]').type('Interested in manually adding new omic unit');
 
     cy.get('.primary-button').contains('Add').click();
     cy.get('[data-test="header-title-text"]').click();
 
-    cy.get('[data-test="JAK2-variant-0"]').as('variantRowJAK2')
+    cy.get('[data-test^="G6PD-variant"]').should('have.length', 1);
+
+    // // Adding Second Manual Omic Unit
+    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').invoke('hide');
+
+    cy.get('[data-test="gene-symbol-input"]').type('JAK2');
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_004972.3');
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.1694G>C');
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Arg565Thr');
+    cy.get('[data-test="reason-of-interest-input"]').type('Second linked omic unit to this other gene');
+
+    cy.get('.primary-button').contains('Add').click();
+    cy.get('[data-test="header-title-text"]').click();
+
+    cy.get('[data-test="JAK2-variant-0"]').as('variantRowJAK2');
     cy.get('@variantRowJAK2').find('.variant-name-row > .variant-name-line')
-        .should('have.text', 'NM_004972.3:c.1694G>C(p.Arg565Thr)')
-    
-    // Editing the first linked omic unit again
+        .should('have.text', 'NM_004972.3:c.1694G>C(p.Arg565Thr)');
+
+    // Editing the first manual omic unit again
     cy.get('@variantRowG6PD').should('have.class', 'editable');
     cy.get('@variantRowG6PD').find('[data-test="edit-button"]').click();
-    cy.get('[data-test="reason-of-interest-input"]').clear().type('Unicorns really eat rainbows.')
+    cy.get('[data-test="reason-of-interest-input"]').clear();
+    cy.get('[data-test="reason-of-interest-input"]').type('Unicorns really eat rainbows.');
     cy.get('.primary-button').contains('Edit').click();
     cy.get('@variantRowG6PD').find('.variant-case-information')
-        .should('contain.text', 'Unicorns really eat rainbows.')
+        .should('contain.text', 'Unicorns really eat rainbows.');
 
-    // Editing the 2nd linked omic unit again
+    // Editing the 2nd manual omic unit again
     cy.get('@variantRowJAK2').should('have.class', 'editable');
     cy.get('@variantRowJAK2').find('[data-test="edit-button"]').click();
-    cy.get('[data-test="reason-of-interest-input"]').clear().type('Its import to link this one and edit the second one only now.')
+    cy.get('[data-test="reason-of-interest-input"]').clear();
+    cy.get('[data-test="reason-of-interest-input"]')
+        .type('Its import to link this one and edit the second one only now.');
     cy.get('.primary-button').contains('Edit').click();
     cy.get('@variantRowJAK2').find('.variant-case-information')
-        .should('contain.text', 'Its import to link this one and edit the second one only now.')
+        .should('contain.text', 'Its import to link this one and edit the second one only now.');
+
+    // Deleting the first manual omic unit
+    cy.get('.gene-box-header').should('have.length', 3);
+    cy.get('@variantRowG6PD').should('have.class', 'editable');
+    cy.get('@variantRowG6PD').find('[data-test="delete-button"]').click();
+
+    cy.get('[data-test="confirm-button"').contains('Delete').click();
+    cy.get('.gene-box-header').should('have.length', 2);
+
+    cy.get('[data-test="gene-name"]')
+        .should('have.length', 2)
+        .each(($el) => {
+          cy.wrap($el).invoke('text').should('not.contain', 'G6PD');
+        });
+
+    // Adding third omic unit but to existing manual gene JAK2
+    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').invoke('hide');
+
+    cy.get('[data-test="gene-symbol-input"]').type('JAK2');
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_004972.4');
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.1849G>A');
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Val617Ile');
+    cy.get('[data-test="reason-of-interest-input"]').type('Third linked omic unit to second added gene');
+
+    cy.get('.primary-button').contains('Add').click();
+    cy.get('[data-test="header-title-text"]').click();
+
+    cy.get('[data-test^="JAK2-variant"]')
+        .as('JAK2Variants')
+        .should('have.length', 2);
+    cy.get('[data-test="JAK2-variant-1"]')
+        .as('secondJAK2Variant')
+        .find('.variant-name-row > .variant-name-line')
+        .should('contain.text', 'NM_004972.4:c.1849G>A(p.Val617Ile)');
+
+    // Editing the first JAK2 variant again and making sure second JAK2 Variant is not affected
+    cy.get('@variantRowJAK2').find('[data-test="edit-button"]').click();
+    cy.get('[data-test="reason-of-interest-input"]').clear();
+    cy.get('[data-test="reason-of-interest-input"]').type('Editing the first JAK2 variant');
+    cy.get('.primary-button').contains('Edit').click();
+    cy.get('@variantRowJAK2').find('.variant-case-information')
+        .should('contain.text', 'Editing the first JAK2 variant');
+
+    cy.get('@secondJAK2Variant').find('.variant-case-information')
+        .should('contain.text', 'Third linked omic unit to second added gene');
+
+    // Adding another variant to the original VMA21 gene that isn't a manually added gene
+    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').invoke('hide');
+
+    cy.get('[data-test="gene-symbol-input"]').type('VMA21');
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_001017980.4');
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.76A>G');
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Thr26Ala');
+    cy.get('[data-test="reason-of-interest-input"]').type('4th omic unit added to original VMA21 gene');
+
+    cy.get('.primary-button').contains('Add').click();
+    cy.get('[data-test="header-title-text"]').click();
+
+    cy.get('[data-test^="VMA21-variant"]')
+        .as('VMA21Variants')
+        .should('have.length', 2);
+    cy.get('[data-test="VMA21-variant-1"]')
+        .as('secondVMA21Variant')
+        .find('.variant-name-row > .variant-name-line')
+        .should('contain.text', 'NM_001017980.4:c.76A>G(p.Thr26Ala)');
+    cy.get('[data-test="VMA21-variant-0"]')
+        .as('originalVMA21Variant')
+        .find('.variant-name-row > .variant-name-line')
+        .should('not.have.class', 'editable');
+    cy.get('@secondVMA21Variant').should('have.class', 'editable');
+
+    // Deleting the first manual omic unit
+    cy.get('.gene-box-header').should('have.length', 2);
+    cy.get('@secondVMA21Variant').find('[data-test="delete-button"]').click();
+
+    cy.get('[data-test="confirm-button"').contains('Delete').click();
+    cy.get('.gene-box-header').should('have.length', 2);
+    cy.get('[data-test^="VMA21-variant"]')
+        .as('VMA21Variants')
+        .should('have.length', 1);
+    cy.get('@originalVMA21Variant')
+        .find('.variant-name-row > .variant-name-line')
+        .should('not.have.class', 'editable');
   });
 });

--- a/system-tests/e2e/add_analysis_omic_unit.cy.js
+++ b/system-tests/e2e/add_analysis_omic_unit.cy.js
@@ -1,0 +1,89 @@
+(Cypress.config('isInteractive') ? describe : describe.skip)('edit_case_analysis.cy.js', () => {
+  beforeEach(() => {
+    cy.resetDatabase();
+    cy.intercept('/rosalution/api/analysis/CPAM0002').as('analysisLoad');
+    cy.visit('analysis/CPAM0002');
+    cy.wait('@analysisLoad');
+  });
+
+  it('adds, edits, and removes new omic units to an analysis', () => {
+    cy.get('[data-test="user-menu"]')
+        .find('.grey-rounded-menu')
+        .as('userActionMenu')
+        .invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;');
+    cy.get('@userActionMenu').contains('Add Unit').click();
+    // cy.get('@userActionMenu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
+
+    //     # new_genomic_unit_dict = {
+    // #     'transcript': "NM_004972.3",
+    // #     'gene': "JAK2",
+    // #     'cdna': "c.1694G>C",
+    // #     'protein': "p.Arg565Thr",
+    // #     'reason_of_interest': "Find this variant interesting to explore.",
+    // # }
+
+    // cy.intercept('/rosalution/api/analysis/CPAM0002/genomic_unit').as('omicUnitChange');
+
+    cy.get('[data-test="gene-symbol-input"]').type('G6PD')
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_001360016.2')
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.563C>T')
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Ser188Phe')
+    cy.get('[data-test="reason-of-interest-input"]').type('Interested in manually adding new omic unit')
+    
+    cy.get('.primary-button').contains('Add').click();
+    // cy.wait('@omicUnitChange')
+    cy.get('[data-test="header-title-text"]').click();
+
+    cy.get('[data-test="G6PD-variant-0"]').as('variantRowG6PD')
+    
+    cy.get('@variantRowG6PD').find('.variant-name-row > .variant-name-line')
+        .should('have.text', 'NM_001360016.2:c.563C>T(p.Ser188Phe)')
+
+    cy.get('@userActionMenu').contains('Edit').click();
+    cy.get('@userActionMenu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
+
+    cy.get('@variantRowG6PD').should('have.class', 'editable');
+    cy.get('@variantRowG6PD').find('[data-test="edit-button"]').click();
+
+    cy.get('[data-test="reason-of-interest-input"]').type('Editing the omic unit of interest')
+    cy.get('.primary-button').contains('Edit').click();
+
+    cy.get('@variantRowG6PD').find('.variant-case-information')
+        .should('have.text', 'Editing the omic unit of interest')
+
+    // cy.get('[data-test="user-menu"]')
+    //     .find('.grey-rounded-menu')
+    //     .as('userActionMenu')
+    //     .invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;');
+    // cy.get('@userActionMenu').contains('Edit').click();
+    // cy.get('@userActionMenu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
+
+    // cy.get('[href="#Brief"]').click();
+    // cy.get('#Brief > div > [data-test="Phenotype"] > .section-content > [data-test="editable-value"]')
+    //     .as('editablePhenotype')
+    //     .click();
+    // cy.get('@editablePhenotype').type('test');
+    // cy.get('@editablePhenotype').should('contain', 'test');
+
+    // // Save the changes to persist the analysis
+    // cy.get('[data-test="save-edit-button"]').should('exist');
+    // cy.get('[data-test="save-edit-button"]').click();
+    // cy.get('[data-test="save-edit-button"]').should('not.exist');
+
+    // // Verify that the changes persist once the save is complete
+    // cy.get('[href="#Brief"]').click();
+    // cy.get('#Brief > div > [data-test="Phenotype"] > .section-content').as('phenotypeField').should('contain', 'test');
+
+    // // Visit CPAM0046 analysis to verify the updated field in CPAM0002 does not appear
+    // cy.visit('analysis/CPAM0046');
+    // cy.wait('@analysisLoad');
+    // cy.get('[href="#Brief"]').click();
+    // cy.get('@phenotypeField').contains('test').should('not.exist');
+
+    // // Return to CPAM0002 analysis and verify the updated field is persisted
+    // cy.visit('analysis/CPAM0002');
+    // cy.wait('@analysisLoad');
+    // cy.get('[href="#Brief"]').click();
+    // cy.get('@phenotypeField').contains('test').should('exist');
+  });
+});

--- a/system-tests/e2e/add_analysis_omic_unit.cy.js
+++ b/system-tests/e2e/add_analysis_omic_unit.cy.js
@@ -9,20 +9,11 @@
   it('adds, edits, and removes new omic units to an analysis', () => {
     cy.get('[data-test="user-menu"]')
         .find('.grey-rounded-menu')
-        .as('userActionMenu')
-        .invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;');
-    cy.get('@userActionMenu').contains('Add Unit').click();
-    // cy.get('@userActionMenu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
+        .invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;')
+        .as('openActionMenu')
 
-    //     # new_genomic_unit_dict = {
-    // #     'transcript': "NM_004972.3",
-    // #     'gene': "JAK2",
-    // #     'cdna': "c.1694G>C",
-    // #     'protein': "p.Arg565Thr",
-    // #     'reason_of_interest': "Find this variant interesting to explore.",
-    // # }
-
-    // cy.intercept('/rosalution/api/analysis/CPAM0002/genomic_unit').as('omicUnitChange');
+    // Adding First Linked Omic Unit
+    cy.get('@openActionMenu').within(() => { cy.contains('Add Unit').click() }).invoke('hide');
 
     cy.get('[data-test="gene-symbol-input"]').type('G6PD')
     cy.get('[data-test="refseq-transcript-input"]').type('NM_001360016.2')
@@ -31,7 +22,6 @@
     cy.get('[data-test="reason-of-interest-input"]').type('Interested in manually adding new omic unit')
     
     cy.get('.primary-button').contains('Add').click();
-    // cy.wait('@omicUnitChange')
     cy.get('[data-test="header-title-text"]').click();
 
     cy.get('[data-test="G6PD-variant-0"]').as('variantRowG6PD')
@@ -39,51 +29,47 @@
     cy.get('@variantRowG6PD').find('.variant-name-row > .variant-name-line')
         .should('have.text', 'NM_001360016.2:c.563C>T(p.Ser188Phe)')
 
-    cy.get('@userActionMenu').contains('Edit').click();
-    cy.get('@userActionMenu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
+    // // Editing First Linked Omic Unit, Must enable Edit Mode to Make omic unit editable
+    cy.get('@openActionMenu').within(() => { cy.contains('Edit').click() }).invoke('hide');
 
     cy.get('@variantRowG6PD').should('have.class', 'editable');
     cy.get('@variantRowG6PD').find('[data-test="edit-button"]').click();
-
-    cy.get('[data-test="reason-of-interest-input"]').type('Editing the omic unit of interest')
+    cy.get('[data-test="reason-of-interest-input"]').clear().type('Editing the omic unit of interest')
     cy.get('.primary-button').contains('Edit').click();
 
     cy.get('@variantRowG6PD').find('.variant-case-information')
-        .should('have.text', 'Editing the omic unit of interest')
+        .should('contain.text', 'Editing the omic unit of interest')
 
-    // cy.get('[data-test="user-menu"]')
-    //     .find('.grey-rounded-menu')
-    //     .as('userActionMenu')
-    //     .invoke('attr', 'style', 'display: block; visibility: visible; opacity: 1;');
-    // cy.get('@userActionMenu').contains('Edit').click();
-    // cy.get('@userActionMenu').invoke('attr', 'style', 'display: block; visibility: hidden; opacity: 0;');
+    // // Adding Second Linked Omic Unit
+    cy.get('@openActionMenu').within(() => { cy.contains('Add Unit').click() }).invoke('hide');
 
-    // cy.get('[href="#Brief"]').click();
-    // cy.get('#Brief > div > [data-test="Phenotype"] > .section-content > [data-test="editable-value"]')
-    //     .as('editablePhenotype')
-    //     .click();
-    // cy.get('@editablePhenotype').type('test');
-    // cy.get('@editablePhenotype').should('contain', 'test');
+    cy.get('[data-test="gene-symbol-input"]').type('JAK2')
+    cy.get('[data-test="refseq-transcript-input"]').type('NM_004972.3')
+    cy.get('[data-test="hgvs-cdna-input"]').type('c.1694G>C')
+    cy.get('[data-test="hgvs-protein-input"]').type('p.Arg565Thr')
+    cy.get('[data-test="reason-of-interest-input"]').type('Second linked omic unit to this other gene')
 
-    // // Save the changes to persist the analysis
-    // cy.get('[data-test="save-edit-button"]').should('exist');
-    // cy.get('[data-test="save-edit-button"]').click();
-    // cy.get('[data-test="save-edit-button"]').should('not.exist');
+    cy.get('.primary-button').contains('Add').click();
+    cy.get('[data-test="header-title-text"]').click();
 
-    // // Verify that the changes persist once the save is complete
-    // cy.get('[href="#Brief"]').click();
-    // cy.get('#Brief > div > [data-test="Phenotype"] > .section-content').as('phenotypeField').should('contain', 'test');
+    cy.get('[data-test="JAK2-variant-0"]').as('variantRowJAK2')
+    cy.get('@variantRowJAK2').find('.variant-name-row > .variant-name-line')
+        .should('have.text', 'NM_004972.3:c.1694G>C(p.Arg565Thr)')
+    
+    // Editing the first linked omic unit again
+    cy.get('@variantRowG6PD').should('have.class', 'editable');
+    cy.get('@variantRowG6PD').find('[data-test="edit-button"]').click();
+    cy.get('[data-test="reason-of-interest-input"]').clear().type('Unicorns really eat rainbows.')
+    cy.get('.primary-button').contains('Edit').click();
+    cy.get('@variantRowG6PD').find('.variant-case-information')
+        .should('contain.text', 'Unicorns really eat rainbows.')
 
-    // // Visit CPAM0046 analysis to verify the updated field in CPAM0002 does not appear
-    // cy.visit('analysis/CPAM0046');
-    // cy.wait('@analysisLoad');
-    // cy.get('[href="#Brief"]').click();
-    // cy.get('@phenotypeField').contains('test').should('not.exist');
-
-    // // Return to CPAM0002 analysis and verify the updated field is persisted
-    // cy.visit('analysis/CPAM0002');
-    // cy.wait('@analysisLoad');
-    // cy.get('[href="#Brief"]').click();
-    // cy.get('@phenotypeField').contains('test').should('exist');
+    // Editing the 2nd linked omic unit again
+    cy.get('@variantRowJAK2').should('have.class', 'editable');
+    cy.get('@variantRowJAK2').find('[data-test="edit-button"]').click();
+    cy.get('[data-test="reason-of-interest-input"]').clear().type('Its import to link this one and edit the second one only now.')
+    cy.get('.primary-button').contains('Edit').click();
+    cy.get('@variantRowJAK2').find('.variant-case-information')
+        .should('contain.text', 'Its import to link this one and edit the second one only now.')
   });
 });

--- a/system-tests/e2e/add_analysis_omic_unit.cy.js
+++ b/system-tests/e2e/add_analysis_omic_unit.cy.js
@@ -1,6 +1,7 @@
 (Cypress.config('isInteractive') ? describe : describe.skip)('edit_case_analysis.cy.js', () => {
   beforeEach(() => {
     cy.resetDatabase();
+    cy.viewport(1400, 900);
     cy.intercept('/rosalution/api/analysis/CPAM0002').as('analysisLoad');
     cy.visit('analysis/CPAM0002');
     cy.wait('@analysisLoad');
@@ -31,7 +32,7 @@
         .should('have.text', 'NM_001360016.2:c.563C>T(p.Ser188Phe)');
 
     // Editing First Manual Omic Unit, Must enable Edit Mode to Make omic unit editable
-    cy.get('@openActionMenu').contains('Add Unit').click();
+    cy.get('@openActionMenu').contains('Edit').click();
     cy.get('@openActionMenu').invoke('hide'); ;
 
     cy.get('@variantRowG6PD').should('have.class', 'editable');

--- a/system-tests/e2e/case_annotation_section_anchors.cy.js
+++ b/system-tests/e2e/case_annotation_section_anchors.cy.js
@@ -7,10 +7,12 @@ describe('case_annotation_display_transcripts.cy.js', () => {
   });
 
   it('navigates to the annotation sections via anchor links', () => {
-    const anchorLinks = ['Gene', 'Variant', 'Protein', 'Chromosomal Localization', 'Secondary Structure', 'Causal Variant',
-      'Variant Publications', 'Gene Homology', 'Human Gene Expression', 'Human Gene versus Protein Expression',
-      'Expression Profiles', 'Orthology', 'Rattus norvegicus Model System', 'Mus musculus Model System',
-      'Danio rerio Model System', 'C elegans Model System', 'Modelability', 'Druggability'];
+    const anchorLinks = ['Gene', 'Variant', 'Protein', 'Chromosomal Localization', 'Secondary Structure',
+      'Causal Variant', 'Variant Publications', 'Gene Homology', 'Human Gene Expression',
+      'Human Gene versus Protein Expression', 'Expression Profiles', 'Orthology', 'Rattus norvegicus Model System',
+      'Mus musculus Model System', 'Danio rerio Model System', 'C elegans Model System', 'Modelability',
+      'Druggability',
+    ];
     const expectedSidebarLinks = [...anchorLinks];
 
     cy.get('.sidebar').find('a').each(($el) => {

--- a/system-tests/e2e/upload_images_to_case_annotations.cy.js
+++ b/system-tests/e2e/upload_images_to_case_annotations.cy.js
@@ -4,7 +4,6 @@ describe('upload_images_to_case_annotations.cy.js', () => {
     cy.fixture('section-image-1.jpg', {encoding: null}).as('sectionImage1');
     cy.fixture('section-image-2.png', {encoding: null}).as('sectionImage2');
     cy.intercept('/rosalution/api/analysis/CPAM0047/summary').as('analysisSummaryLoad');
-
   });
 
   it('manages successully and failed attempts to upload images for users', () => {
@@ -16,7 +15,7 @@ describe('upload_images_to_case_annotations.cy.js', () => {
     cy.get('[data-test="Gene Homology/Multi-Sequence Alignment"]').should('not.have.descendants', 'button');
 
     // Test uploading a single image
-    cy.login('vrr-prep')
+    cy.login('vrr-prep');
     cy.visit('/analysis/CPAM0047/annotation/');
     cy.wait('@analysisSummaryLoad');
     cy.get('[href="/rosalution/analysis/CPAM0047/annotation#Gene_Homology"]').click();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines enforced by static analysis tools.
- [x] If it is a core feature, I have added thorough tests.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] New or existing JSON is formatted using JQ
- [x] I have updated the CHANGELOG to note of any product updates that will be going in with this pull request.

## Pull Request Details

Wrike Ticket - [Standard User; 'link' 'omic units to analyses as units of interests to examine for review](https://www.wrike.com/open.htm?id=1783253364)

Changes made:

- Adding support for editing and removing of manually added variants in analyses in "Edit Mode"
- System test to capture the e2e regression testing of the workload

- Chore: 
  - Rosalution's staging deployment used for dev is fixed, ensuring that after this gets merged in, nightly builds and deployments start happening again.

**To Review:**
<!-- Make a to do list of things to check for to approve the pull request -->
<!-- Modify the below list as appropriate by editing and deleting text that is not applicable-->

- [x] Static Analysis by Reviewer
- [x] The changes made to < describe purpose of change > are working as intended/rendered correctly.
  To check this run the following commands:

  ``` bash
  docker compose down
  docker system prune -a --volumes
  docker compose up --build -d
  ```

    - Visit <https://local.rosalution.cgds/rosalution/login>. Login as `developer`.
    - Visit <https://local.rosalution.cgds/rosalution/analysis/CPAM0002>
    - Open Top Right Action Menu to Add a Variant
      <img width="1484" height="735" alt="image" src="https://github.com/user-attachments/assets/44f839a7-7b5e-42dd-81f1-b43a909a6337" />
    - Fill out the Modal Dialog Form Fields with the following. Once complete, Click the "Add" Button
      - Gene Symbol: G6PD
      - RefSeq Transcript: NM_001360016.2
      - HGVS cDNA: c.563C>T
      - HGVS Protein: p.Ser188Phe
      - Reason of Interest: Interested in manually adding new omic unit
      <img width="1125" height="711" alt="image" src="https://github.com/user-attachments/assets/13b6f048-fbbd-4781-ad5c-62ac42ddf5de" />
    - Open Top Right Action Menu and choose "Edit" to enable Edit Mode, the manually added variants have grey backgrounds with edit and remove options to the right.
    <img width="1438" height="484" alt="image" src="https://github.com/user-attachments/assets/aab2d16d-eaf3-48bf-9c98-e7016e49f61e" />
    - Click the pencil icon on the right side of the page of the added variant, and a similar modal dialog will popup with only the "Reason of Interest" field as editable. Change the test for your reason of interest and click the "edit" button.
    <img width="1461" height="765" alt="image" src="https://github.com/user-attachments/assets/f46fd9f8-6380-4ee1-a8af-7e8d5d76ee6c" />
    - Observe that the variant has been edited.
    <img width="1412" height="567" alt="image" src="https://github.com/user-attachments/assets/a90da1f6-e0f1-4e06-b80e-a675cae0ddae" />
    - Remove the manually added variant using the 'x' button to the right of the variant. A confirmation modal should appear confirming if you want to delete this variant.
    <img width="1413" height="528" alt="image" src="https://github.com/user-attachments/assets/686a5a9f-78bb-4031-a3ff-89a2380ea22e" />
    - Observe the variant and G6PD gene section has been removed. Note: the screenshot below had demonstrated adding a second variant, which is why a JAK2 Gene section box is present.  
    <img width="1404" height="374" alt="image" src="https://github.com/user-attachments/assets/ad8d42ef-5114-4b01-a231-da50c9d62e2c" />
- [ ] All Github Actions checks have passed.

